### PR TITLE
Make scopes parameter to ConfidentialClientAuth optional

### DIFF
--- a/changelog/@unreleased/pr-20.v2.yml
+++ b/changelog/@unreleased/pr-20.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Make scopes parameter to ConfidentialClientAuth optional
+  links:
+  - https://github.com/palantir/foundry-platform-python/pull/20

--- a/foundry/_core/confidential_client_auth.py
+++ b/foundry/_core/confidential_client_auth.py
@@ -51,11 +51,6 @@ class ConfidentialClientAuth(Auth):
         scopes: Optional[List[str]] = None,
         should_refresh: bool = False,
     ) -> None:
-        if len(scopes) == 0:
-            raise ValueError(
-                "You have not provided any scopes. At least one scope must be provided."
-            )
-
         self._client_id = client_id
         self._client_secret = client_secret
         self._token: Optional[OAuthToken] = None

--- a/foundry/_core/confidential_client_auth.py
+++ b/foundry/_core/confidential_client_auth.py
@@ -48,7 +48,7 @@ class ConfidentialClientAuth(Auth):
         client_id: str,
         client_secret: str,
         hostname: str,
-        scopes: List[str],
+        scopes: Optional[List[str]] = None,
         should_refresh: bool = False,
     ) -> None:
         if len(scopes) == 0:

--- a/test/auth/test_foundry_oauth_client.py
+++ b/test/auth/test_foundry_oauth_client.py
@@ -17,6 +17,7 @@ import pytest
 from foundry import ConfidentialClientAuth
 from foundry._errors.not_authenticated import NotAuthenticated
 
+
 def test_can_pass_config():
     config = ConfidentialClientAuth(
         client_id="123",

--- a/test/auth/test_foundry_oauth_client.py
+++ b/test/auth/test_foundry_oauth_client.py
@@ -17,21 +17,6 @@ import pytest
 from foundry import ConfidentialClientAuth
 from foundry._errors.not_authenticated import NotAuthenticated
 
-
-def test_fails_no_escopes():
-    with pytest.raises(ValueError) as info:
-        ConfidentialClientAuth(
-            client_id="123",
-            client_secret="abc",
-            hostname="example.com",
-            scopes=[],
-        )
-
-    assert (
-        str(info.value) == "You have not provided any scopes. At least one scope must be provided."
-    )
-
-
 def test_can_pass_config():
     config = ConfidentialClientAuth(
         client_id="123",


### PR DESCRIPTION
The multipass token endpoint supports retrieving a token without specifying scopes. We should support the same flow in the SDK.