### PR TITLE
Adding py.typed file

### DIFF
--- a/changelog/@unreleased/pr-74.v2.yml
+++ b/changelog/@unreleased/pr-74.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Adding py.typed file
+  links:
+  - https://github.com/palantir/foundry-platform-python/pull/74


### PR DESCRIPTION
Adding py.typed in our distribution, so during checks, mypy recognizes that the package has type annotations.