### PR TITLE
Fix bug where explicit scopes were being required unintentionally

### DIFF
--- a/changelog/@unreleased/pr-103.v2.yml
+++ b/changelog/@unreleased/pr-103.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix bug causing no explicit scope to be translated to the scope just
+    containing the `offline_access` operation in `ConfidentialClientOAuthFlowProvider`.
+  links:
+  - https://github.com/palantir/foundry-platform-python/pull/103

--- a/foundry/_core/oauth_utils.py
+++ b/foundry/_core/oauth_utils.py
@@ -162,11 +162,9 @@ class ConfidentialClientOAuthFlowProvider:
         revoke_token_response.raise_for_status()
 
     def get_scopes(self) -> List[str]:
-        scopes = []
-        if self.scopes:
-            scopes.extend(self.scopes)
-        scopes.append("offline_access")
-        return scopes
+        if not self.scopes:
+            return []
+        return ["offline_access", *self.scopes]
 
 
 def generate_random_string(min_length: int = 43, max_length: int = 128) -> str:

--- a/foundry/_core/oauth_utils.py
+++ b/foundry/_core/oauth_utils.py
@@ -164,7 +164,7 @@ class ConfidentialClientOAuthFlowProvider:
     def get_scopes(self) -> List[str]:
         if not self.scopes:
             return []
-        return ["offline_access", *self.scopes]
+        return [*self.scopes, "offline_access"]
 
 
 def generate_random_string(min_length: int = 43, max_length: int = 128) -> str:


### PR DESCRIPTION
As documented at https://github.com/palantir/foundry-platform-python/blob/develop/foundry/_core/confidential_client_auth.py#L40 , the intended behavior for "no scopes specified" is that the token is unscoped. However, due to the incorrect logic that is fixed in this PR, no scopes were being translated to a scope just containing the `offline_access` operation (which meant essentially that the token could not do anything).