### PR TITLE
Add BLOBSTER_PDF to resource type list

### DIFF
--- a/foundry/v2/filesystem/models.py
+++ b/foundry/v2/filesystem/models.py
@@ -632,6 +632,7 @@ ResourceType = typing.Literal[
     "BLOBSTER_CODE",
     "BLOBSTER_DOCUMENT",
     "BLOBSTER_IMAGE",
+    "BLOBSTER_PDF",
     "BLOBSTER_SPREADSHEET",
     "CARBON_WORKSPACE",
     "COMPASS_FOLDER",


### PR DESCRIPTION
As reported by a user on the community forum ( https://community.palantir.com/t/unable-to-retrieve-certain-resources-using-foundry-platform-sdk/3183 ), we currently get an error on type-checking the `BLOBSTER_PDF` return value here due to it being missing from the list of possible values.

EDIT: Ah, this file is autogenerated from a Conjure IR via an Excavator. I guess that I should be PRing this somewhere else.