### PR TITLE
Config Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ client.datasets.Dataset.Branch.create(
 If you did this, you would receive an error that looks something like:
 
 ```python
-pydantic_core._pydantic_core.ValidationError: 1 validation error for upload
+pydantic_core._pydantic_core.ValidationError: 1 validation error for create
 transaction_rid
   Input should be a valid string [type=string_type, input_value=123, input_type=int]
     For further information visit https://errors.pydantic.dev/2.5/v/string_type
@@ -308,9 +308,7 @@ of data, while handling the underlying pagination logic.
 To iterate over all items, you can simply create a `Pager` instance and use it in a for loop, like this:
 
 ```python
-for item in client.datasets.Dataset.Branch.list(
-    dataset_rid, page_size=page_size, page_token=page_token
-):
+for item in client.datasets.Dataset.Branch.list(dataset_rid):
     print(item)
 
 ```

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ for item in client.datasets.Dataset.Branch.list(dataset_rid):
 This will automatically fetch and iterate through all the pages of data from the specified API endpoint. For more granular control, you can manually fetch each page using the `next_page_token`.
 
 ```python
-page = client.datasets.Dataset.Branch.list(dataset_rid, page_size=page_size, page_token=page_token)
+page = client.datasets.Dataset.Branch.list(dataset_rid, page_size=page_size)
 
 while page.next_page_token:
     for branch in page.data:

--- a/README.md
+++ b/README.md
@@ -7,18 +7,19 @@
 > [!WARNING]
 > This SDK is incubating and subject to change.
 
-The Foundry Platform SDK is a Python SDK built on top of the Foundry API. Review [Foundry API documentation](https://www.palantir.com/docs/foundry/api/) for more details.
+The Foundry Platform SDK is a Python SDK built on top of the Foundry API.
+Review [Foundry API documentation](https://www.palantir.com/docs/foundry/api/) for more details.
 
 > [!NOTE]
 > This Python package is automatically generated based on the Foundry API specification.
 
 
 <a id="sdk-vs-sdk"></a>
-## Foundry Platform SDK vs. Ontology SDK
-Palantir provides two different Python Software Development Kits (SDKs) for interacting with Foundry. Make sure to choose the correct SDK for your use case. As a general rule of thumb, any applications which leverage the Ontology should use the Ontology SDK for a superior development experience.
+## Gotham Platform SDK vs. Foundry Platform SDK vs. Ontology SDK
+Palantir provides two platform APIs for interacting with the Gotham and Foundry platforms. Each has a corresponding Software Development Kit (SDK). There is also the OSDK for interacting with Foundry ontologies. Make sure to choose the correct SDK for your use case. As a general rule of thumb, any applications which leverage the Ontology should use the Ontology SDK over the Foundry platform SDK for a superior development experience.
 
 > [!IMPORTANT]
-> Make sure to understand the difference between the Foundry SDK and the Ontology SDK. Review this section before continuing with the installation of this library.
+> Make sure to understand the difference between the Foundry, Gotham, and Ontology SDKs. Review this section before continuing with the installation of this library.
 
 ### Ontology SDK
 The Ontology SDK allows you to access the full power of the Ontology directly from your development environment. You can generate the Ontology SDK using the Developer Console, a portal for creating and managing applications using Palantir APIs. Review the [Ontology SDK documentation](https://www.palantir.com/docs/foundry/ontology-sdk) for more information.
@@ -26,8 +27,13 @@ The Ontology SDK allows you to access the full power of the Ontology directly fr
 ### Foundry Platform SDK
 The Foundry Platform Software Development Kit (SDK) is generated from the Foundry API specification
 file. The intention of this SDK is to encompass endpoints related to interacting
-with the platform itself. Although there are Ontology services included by this SDK, this SDK surfaces endpoints
+with the Foundry platform itself. Although there are Ontology services included by this SDK, this SDK surfaces endpoints
 for interacting with Ontological resources such as object types, link types, and action types. In contrast, the OSDK allows you to interact with objects, links and Actions (for example, querying your objects, applying an action).
+
+### Gotham Platform SDK
+The Gotham Platform Software Development Kit (SDK) is generated from the Gotham API specification
+file. The intention of this SDK is to encompass endpoints related to interacting
+with the Gotham platform itself. This includes Gotham apps and data, such as Gaia, Target Workbench, and geotemporal data.
 
 <a id="installation"></a>
 ## Installation
@@ -59,7 +65,7 @@ There are two options for authorizing the SDK.
 
 ### User token
 > [!WARNING]
-> User tokens are associated with your personal Foundry user account and must not be used in
+> User tokens are associated with your personal user account and must not be used in
 > production applications or committed to shared or public code repositories. We recommend
 > you store test API tokens as environment variables during development. For authorizing
 > production applications, you should register an OAuth2 application (see
@@ -84,10 +90,11 @@ initializing the `UserTokenAuth`:
 import foundry
 import foundry.v2
 
-foundry_client = foundry.v2.FoundryClient(
+client = foundry.v2.FoundryClient(
     auth=foundry.UserTokenAuth(token=os.environ["BEARER_TOKEN"]),
     hostname="example.palantirfoundry.com",
 )
+
 ```
 
 <a id="oauth2-client"></a>
@@ -97,7 +104,7 @@ natively supports the [client credentials grant flow](https://www.palantir.com/d
 The token obtained by this grant can be used to access resources on behalf of the created service user. To use this
 authentication method, you will first need to register a third-party application in Foundry by following [the guide on third-party application registration](https://www.palantir.com/docs/foundry/platform-security-third-party/register-3pa).
 
-To use the confidential client functionality, you first need to contstruct a
+To use the confidential client functionality, you first need to construct a
 `ConfidentialClientAuth` object. As these service user tokens have a short
 lifespan (one hour), we automatically retry all operations one time if a `401`
 (Unauthorized) error is thrown after refreshing the token.
@@ -110,6 +117,7 @@ auth = foundry.ConfidentialClientAuth(
     client_secret=os.environ["CLIENT_SECRET"],
     scopes=[...],  # optional list of scopes
 )
+
 ```
 
 > [!IMPORTANT]
@@ -121,7 +129,8 @@ After creating the `ConfidentialClientAuth` object, pass it in to the `FoundryCl
 ```python
 import foundry.v2
 
-foundry_client = foundry.v2.FoundryClient(auth=auth, hostname="example.palantirfoundry.com")
+client = foundry.v2.FoundryClient(auth=auth, hostname="example.palantirfoundry.com")
+
 ```
 
 > [!TIP]
@@ -137,27 +146,23 @@ best suited for your instance before following this example. For simplicity, the
 purposes.
 
 ```python
-from foundry.v1 import FoundryClient
+from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
-# DatasetRid | The Resource Identifier (RID) of the Dataset on which to create the Branch.
-dataset_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
-# BranchId
-branch_id = "my-branch"
-# Optional[TransactionRid]
-transaction_rid = None
+# DatasetRid
+dataset_rid = None
+# BranchName
+name = "master"
+# Optional[TransactionRid] | The most recent OPEN or COMMITTED transaction on the branch. This will never be an ABORTED transaction.
+transaction_rid = "ri.foundry.main.transaction.0a0207cb-26b7-415b-bc80-66a3aa3933f4"
 
 
 try:
     api_response = foundry_client.datasets.Dataset.Branch.create(
-        dataset_rid,
-        branch_id=branch_id,
-        transaction_rid=transaction_rid,
+        dataset_rid, name=name, transaction_rid=transaction_rid
     )
     print("The create response:\n")
     pprint(api_response)
@@ -182,20 +187,20 @@ of arguments. In the example below, we are passing in a number to `transaction_r
 which should actually be a string type:
 
 ```python
-foundry_client.datasets.Dataset.Branch.create(
-    "ri.foundry.main.dataset.abc",
-    name="123",
-    transaction_rid=123,
-)
+client.datasets.Dataset.Branch.create(
+	dataset_rid, 
+	name=name, 
+	transaction_rid=123)
 ```
 
 If you did this, you would receive an error that looks something like:
 
-```
-pydantic_core._pydantic_core.ValidationError: 1 validation error for create
+```python
+pydantic_core._pydantic_core.ValidationError: 1 validation error for upload
 transaction_rid
   Input should be a valid string [type=string_type, input_value=123, input_type=int]
     For further information visit https://errors.pydantic.dev/2.5/v/string_type
+
 ```
 
 To handle these errors, you can catch `pydantic.ValidationError`. To learn more, see
@@ -207,9 +212,7 @@ the [Pydantic error documentation](https://docs.pydantic.dev/latest/errors/error
 experience. See [Static Type Analysis](#static-types) below for more information.
 
 ### HTTP exceptions
-Each operation includes a list of possible exceptions that can be thrown which can be thrown by
-the server, all of which inherit from `PalantirRPCException`. For example, an operation that interacts
-with datasets might throw a `DatasetNotFound` error, which is defined as follows:
+Each operation includes a list of possible exceptions that can be thrown which can be thrown by the server, all of which inherit from `PalantirRPCException`. For example, an operation that interacts with datasets might throw a `DatasetNotFound` error, which is defined as follows:
 
 ```python
 class DatasetNotFoundParameters(TypedDict):
@@ -225,6 +228,7 @@ class DatasetNotFound(NotFoundError):
     name: Literal["DatasetNotFound"]
     parameters: DatasetNotFoundParameters
     error_instance_id: str
+
 ```
 
 As a user, you can catch this exception and handle it accordingly.
@@ -233,10 +237,11 @@ As a user, you can catch this exception and handle it accordingly.
 from foundry.v2.datasets.errors import DatasetNotFound
 
 try:
-    dataset = foundry_client.datasets.Dataset.get("ri.foundry.main.dataset.abc")
+    response = client.datasets.Dataset.get(dataset_rid)
     ...
 except DatasetNotFound as e:
-    print("Dataset not found", e.parameters["datasetRid"])
+    print("There was an error with the request", e.parameters[...])
+
 ```
 
 You can refer to the method documentation to see which exceptions can be thrown. It is also possible to
@@ -257,22 +262,22 @@ catch a generic subclass of `PalantirRPCException` such as `BadRequestError` or 
 
 ```python
 from foundry import PalantirRPCException
-from foundry import NotFoundError
-
+from foundry import UnauthorizedError
 
 try:
-    api_response = foundry_client.datasets.Transaction.abort(dataset_rid, transaction_rid)
+    api_response = client.datasets.Dataset.get(dataset_rid)
     ...
-except NotFoundError as e:
-    print("Dataset or Transaction not found", e)
+except UnauthorizedError as e:
+    print("There was an error with the request", e)
 except PalantirRPCException as e:
     print("Another HTTP exception occurred", e)
+
 ```
 
 All HTTP exceptions will have the following properties. See the [Foundry API docs](https://www.palantir.com/docs/foundry/api/general/overview/errors) for details about the Foundry error information.
 
-| Property          | Type                   | Description                                                                                                                    |
-| ----------------- | -----------------------| ------------------------------------------------------------------------------------------------------------------------------ |
+| Property          | Type                   | Description                                                                                                                                                       |
+| ----------------- | -----------------------| ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | name              | str                    | The Palantir error name. See the [Foundry API docs](https://www.palantir.com/docs/foundry/api/general/overview/errors).        |
 | error_instance_id | str                    | The Palantir error instance ID. See the [Foundry API docs](https://www.palantir.com/docs/foundry/api/general/overview/errors). |
 | parameters        | Dict[str, Any]         | The Palantir error parameters. See the [Foundry API docs](https://www.palantir.com/docs/foundry/api/general/overview/errors).  |
@@ -303,19 +308,26 @@ of data, while handling the underlying pagination logic.
 To iterate over all items, you can simply create a `Pager` instance and use it in a for loop, like this:
 
 ```python
-for branch in foundry_client.datasets.Dataset.Branch.list(dataset_rid):
-    print(branch)
+for item in client.datasets.Dataset.Branch.list(
+    dataset_rid, page_size=page_size, page_token=page_token
+):
+    print(item)
+
 ```
 
 This will automatically fetch and iterate through all the pages of data from the specified API endpoint. For more granular control, you can manually fetch each page using the `next_page_token`.
 
 ```python
-page = foundry_client.datasets.Dataset.Branch.list(dataset_rid)
+page = client.datasets.Dataset.Branch.list(dataset_rid, page_size=page_size, page_token=page_token)
+
 while page.next_page_token:
     for branch in page.data:
         print(branch)
 
-    page = foundry_client.datasets.Dataset.Branch.list(dataset_rid, page_token=page.next_page_token)
+    page = client.datasets.Dataset.Branch.list(
+        dataset_rid, page_size=page_size, page_token=page.next_page_token
+    )
+
 ```
 
 
@@ -327,14 +339,15 @@ manager when making a request with this client.
 
 ```python
 # Non-streaming response
-with open("profile_picture.png", "wb") as f:
-    f.write(foundry_client.admin.User.profile_picture(user_id))
+with open("result.png", "wb") as f:
+    f.write(client.admin.User.profile_picture(user_id))
 
 # Streaming response
-with open("profile_picture.png", "wb") as f:
-    with foundry_client.admin.User.with_streaming_response.profile_picture(user_id) as response:
+with open("result.png", "wb") as f:
+    with client.admin.User.with_streaming_response.profile_picture(user_id) as response:
         for chunk in response.iter_bytes():
             f.write(chunk)
+
 ```
 
 <a id="static-types"></a>
@@ -357,6 +370,7 @@ class. For example, here is how `Group.search` method is defined in the `Admin` 
         request_timeout: Optional[Annotated[int, pydantic.Field(gt=0)]] = None,
     ) -> SearchGroupsResponse:
         ...
+
 ```
 
 In this example, `GroupSearchFilter` is a `BaseModel` class and `GroupSearchFilterDict` is a `TypedDict` class. When calling this method,
@@ -373,6 +387,7 @@ result = client.admin.Group.search(where=GroupSearchFilter(type="queryString", v
 
 # Dict
 result = client.admin.Group.search(where={"type": "queryString", "value": "John Doe"})
+
 ```
 
 > [!TIP]
@@ -394,8 +409,8 @@ branch = foundry_client.datasets.Dataset.Branch.create(
 )
 # ERROR: Cannot access member "branchName" for type "Branch"
 print(branch.branchName)
-```
 
+```
 
 <a id="session-config"></a>
 ## HTTP Session Configuration
@@ -404,7 +419,7 @@ You can configure various parts of the HTTP session using the `Config` class.
 ```python
 from foundry import Config
 from foundry import UserTokenAuth
-from foundry.v2 imoprt FoundryClient
+from foundry.v2 import FoundryClient
 
 client = FoundryClient(
     auth=UserTokenAuth(...),
@@ -415,11 +430,10 @@ client = FoundryClient(
         # Default to a 60 second timeout
         timeout=60,
         # Create a proxy for the https protocol
-        proxies={
-            "https": "https://10.10.1.10:1080"
-        },
-    )
+        proxies={"https": "https://10.10.1.10:1080"},
+    ),
 )
+
 ```
 
 The full list of options can be found below.

--- a/changelog/@unreleased/pr-177.v2.yml
+++ b/changelog/@unreleased/pr-177.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Config Refactor
+  links:
+  - https://github.com/palantir/foundry-platform-python/pull/177

--- a/config.json
+++ b/config.json
@@ -3,8 +3,10 @@
   "packageUrl": "https://github.com/palantir/foundry-platform-python",
   "projectName": "foundry-platform-sdk",
   "clientName": "FoundryClient",
+  "platformName": "Foundry",
   "userHeader": "python-foundry-platform-sdk",
   "description": "The official Python library for the Foundry API",
+  "promotedMajorVersion": "v2",
   "extraDocsDir": "assets/docs_examples",
   "exampleOperation": {
     "majorVersion": "v2",

--- a/config.json
+++ b/config.json
@@ -6,7 +6,43 @@
   "userHeader": "python-foundry-platform-sdk",
   "description": "The official Python library for the Foundry API",
   "extraDocsDir": "assets/docs_examples",
-  "exampleOperationName": "createBranch",
+  "exampleOperation": {
+    "majorVersion": "v2",
+    "operationName": "createBranch"
+  },
+  "validation": {
+    "exampleOperation": {
+      "majorVersion": "v2",
+      "operationName": "createBranch"
+    },
+    "exampleParameter": "transaction_rid",
+    "exampleVerb": "upload"
+  },
+  "exceptions": {
+    "exampleOperation": {
+      "majorVersion": "v2",
+      "operationName": "getDataset"
+    },
+    "packageName": "datasets",
+    "exampleError": "DatasetNotFound",
+    "exampleGenericError": "UnauthorizedError",
+    "exampleErrorMessage": "There was an error with the request"
+  },
+  "paginationExampleOperation": {
+    "majorVersion": "v2",
+    "operationName": "listBranches"
+  },
+  "streamingExampleOperation": {
+    "majorVersion": "v2",
+    "operationName": "getProfilePictureOfUser"
+  },
+  "staticTypes": {
+    "exampleNamespace": "Admin",
+    "exampleOperation": {
+      "majorVersion": "v2",
+      "operationName": "searchUsers"
+    }
+  },
   "majorVersionConfigs": {
     "v1": {
       "additionalRelationships": [

--- a/config.json
+++ b/config.json
@@ -16,7 +16,7 @@
       "operationName": "createBranch"
     },
     "exampleParameter": "transaction_rid",
-    "exampleVerb": "upload"
+    "exampleVerb": "create"
   },
   "exceptions": {
     "exampleOperation": {

--- a/docs/v1/Datasets/Branch.md
+++ b/docs/v1/Datasets/Branch.md
@@ -32,9 +32,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The Resource Identifier (RID) of the Dataset on which to create the Branch.
 dataset_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -46,9 +44,7 @@ transaction_rid = None
 
 try:
     api_response = foundry_client.datasets.Dataset.Branch.create(
-        dataset_rid,
-        branch_id=branch_id,
-        transaction_rid=transaction_rid,
+        dataset_rid, branch_id=branch_id, transaction_rid=transaction_rid
     )
     print("The create response:\n")
     pprint(api_response)
@@ -93,9 +89,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The Resource Identifier (RID) of the Dataset that contains the Branch.
 dataset_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -104,10 +98,7 @@ branch_id = "my-branch"
 
 
 try:
-    api_response = foundry_client.datasets.Dataset.Branch.delete(
-        dataset_rid,
-        branch_id,
-    )
+    api_response = foundry_client.datasets.Dataset.Branch.delete(dataset_rid, branch_id)
     print("The delete response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -151,9 +142,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The Resource Identifier (RID) of the Dataset that contains the Branch.
 dataset_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -162,10 +151,7 @@ branch_id = "master"
 
 
 try:
-    api_response = foundry_client.datasets.Dataset.Branch.get(
-        dataset_rid,
-        branch_id,
-    )
+    api_response = foundry_client.datasets.Dataset.Branch.get(dataset_rid, branch_id)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -210,9 +196,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The Resource Identifier (RID) of the Dataset on which to list Branches.
 dataset_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -223,10 +207,8 @@ page_token = None
 
 
 try:
-    for branch in foundry_client.datasets.Dataset.Branch.list(
-        dataset_rid,
-        page_size=page_size,
-        page_token=page_token,
+    for branch in client.datasets.Dataset.Branch.list(
+        dataset_rid, page_size=page_size, page_token=page_token
     ):
         pprint(branch)
 except foundry.PalantirRPCException as e:
@@ -271,9 +253,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The Resource Identifier (RID) of the Dataset on which to list Branches.
 dataset_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -285,9 +265,7 @@ page_token = None
 
 try:
     api_response = foundry_client.datasets.Dataset.Branch.page(
-        dataset_rid,
-        page_size=page_size,
-        page_token=page_token,
+        dataset_rid, page_size=page_size, page_token=page_token
     )
     print("The page response:\n")
     pprint(api_response)

--- a/docs/v1/Datasets/Dataset.md
+++ b/docs/v1/Datasets/Dataset.md
@@ -32,9 +32,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetName
 name = "My Dataset"
@@ -44,8 +42,7 @@ parent_folder_rid = "ri.foundry.main.folder.bfe58487-4c56-4c58-aba7-25defd6163c4
 
 try:
     api_response = foundry_client.datasets.Dataset.create(
-        name=name,
-        parent_folder_rid=parent_folder_rid,
+        name=name, parent_folder_rid=parent_folder_rid
     )
     print("The create response:\n")
     pprint(api_response)
@@ -90,9 +87,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The RID of the Dataset on which to delete the schema.
 dataset_rid = None
@@ -106,10 +101,7 @@ transaction_rid = None
 
 try:
     api_response = foundry_client.datasets.Dataset.delete_schema(
-        dataset_rid,
-        branch_id=branch_id,
-        preview=preview,
-        transaction_rid=transaction_rid,
+        dataset_rid, branch_id=branch_id, preview=preview, transaction_rid=transaction_rid
     )
     print("The delete_schema response:\n")
     pprint(api_response)
@@ -153,18 +145,14 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
 
 
 try:
-    api_response = foundry_client.datasets.Dataset.get(
-        dataset_rid,
-    )
+    api_response = foundry_client.datasets.Dataset.get(dataset_rid)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -208,9 +196,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The RID of the Dataset.
 dataset_rid = None
@@ -224,10 +210,7 @@ transaction_rid = None
 
 try:
     api_response = foundry_client.datasets.Dataset.get_schema(
-        dataset_rid,
-        branch_id=branch_id,
-        preview=preview,
-        transaction_rid=transaction_rid,
+        dataset_rid, branch_id=branch_id, preview=preview, transaction_rid=transaction_rid
     )
     print("The get_schema response:\n")
     pprint(api_response)
@@ -279,9 +262,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The RID of the Dataset.
 dataset_rid = None
@@ -409,9 +390,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The RID of the Dataset on which to put the Schema.
 dataset_rid = None
@@ -425,10 +404,7 @@ preview = True
 
 try:
     api_response = foundry_client.datasets.Dataset.replace_schema(
-        dataset_rid,
-        body,
-        branch_id=branch_id,
-        preview=preview,
+        dataset_rid, body, branch_id=branch_id, preview=preview
     )
     print("The replace_schema response:\n")
     pprint(api_response)

--- a/docs/v1/Datasets/File.md
+++ b/docs/v1/Datasets/File.md
@@ -47,9 +47,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The Resource Identifier (RID) of the Dataset on which to delete the File.
 dataset_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -63,10 +61,7 @@ transaction_rid = None
 
 try:
     api_response = foundry_client.datasets.Dataset.File.delete(
-        dataset_rid,
-        file_path,
-        branch_id=branch_id,
-        transaction_rid=transaction_rid,
+        dataset_rid, file_path, branch_id=branch_id, transaction_rid=transaction_rid
     )
     print("The delete response:\n")
     pprint(api_response)
@@ -135,9 +130,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The Resource Identifier (RID) of the Dataset that contains the File.
 dataset_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -229,9 +222,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The Resource Identifier (RID) of the Dataset on which to list Files.
 dataset_rid = None
@@ -248,7 +239,7 @@ start_transaction_rid = None
 
 
 try:
-    for file in foundry_client.datasets.Dataset.File.list(
+    for file in client.datasets.Dataset.File.list(
         dataset_rid,
         branch_id=branch_id,
         end_transaction_rid=end_transaction_rid,
@@ -345,9 +336,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The Resource Identifier (RID) of the Dataset on which to list Files.
 dataset_rid = None
@@ -440,9 +429,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The Resource Identifier (RID) of the Dataset that contains the File.
 dataset_rid = None
@@ -528,9 +515,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The Resource Identifier (RID) of the Dataset on which to upload the File.
 dataset_rid = None

--- a/docs/v1/Datasets/Transaction.md
+++ b/docs/v1/Datasets/Transaction.md
@@ -31,9 +31,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The Resource Identifier (RID) of the Dataset that contains the Transaction.
 dataset_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -42,10 +40,7 @@ transaction_rid = "ri.foundry.main.transaction.abffc380-ea68-4843-9be1-9f44d2565
 
 
 try:
-    api_response = foundry_client.datasets.Dataset.Transaction.abort(
-        dataset_rid,
-        transaction_rid,
-    )
+    api_response = foundry_client.datasets.Dataset.Transaction.abort(dataset_rid, transaction_rid)
     print("The abort response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -90,9 +85,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The Resource Identifier (RID) of the Dataset that contains the Transaction.
 dataset_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -101,10 +94,7 @@ transaction_rid = "ri.foundry.main.transaction.abffc380-ea68-4843-9be1-9f44d2565
 
 
 try:
-    api_response = foundry_client.datasets.Dataset.Transaction.commit(
-        dataset_rid,
-        transaction_rid,
-    )
+    api_response = foundry_client.datasets.Dataset.Transaction.commit(dataset_rid, transaction_rid)
     print("The commit response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -149,9 +139,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The Resource Identifier (RID) of the Dataset on which to create the Transaction.
 dataset_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -163,9 +151,7 @@ transaction_type = "SNAPSHOT"
 
 try:
     api_response = foundry_client.datasets.Dataset.Transaction.create(
-        dataset_rid,
-        branch_id=branch_id,
-        transaction_type=transaction_type,
+        dataset_rid, branch_id=branch_id, transaction_type=transaction_type
     )
     print("The create response:\n")
     pprint(api_response)
@@ -232,9 +218,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid | The Resource Identifier (RID) of the Dataset that contains the Transaction.
 dataset_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -243,10 +227,7 @@ transaction_rid = "ri.foundry.main.transaction.abffc380-ea68-4843-9be1-9f44d2565
 
 
 try:
-    api_response = foundry_client.datasets.Dataset.Transaction.get(
-        dataset_rid,
-        transaction_rid,
-    )
+    api_response = foundry_client.datasets.Dataset.Transaction.get(dataset_rid, transaction_rid)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:

--- a/docs/v1/Ontologies/Action.md
+++ b/docs/v1/Ontologies/Action.md
@@ -35,9 +35,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the action. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -49,9 +47,7 @@ parameters = {"id": 80060, "newName": "Anna Smith-Doe"}
 
 try:
     api_response = foundry_client.ontologies.Action.apply(
-        ontology_rid,
-        action_type,
-        parameters=parameters,
+        ontology_rid, action_type, parameters=parameters
     )
     print("The apply response:\n")
     pprint(api_response)
@@ -105,9 +101,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the action. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -122,9 +116,7 @@ requests = [
 
 try:
     api_response = foundry_client.ontologies.Action.apply_batch(
-        ontology_rid,
-        action_type,
-        requests=requests,
+        ontology_rid, action_type, requests=requests
     )
     print("The apply_batch response:\n")
     pprint(api_response)
@@ -177,9 +169,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the action. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -203,9 +193,7 @@ parameters = {
 
 try:
     api_response = foundry_client.ontologies.Action.validate(
-        ontology_rid,
-        action_type,
-        parameters=parameters,
+        ontology_rid, action_type, parameters=parameters
     )
     print("The validate response:\n")
     pprint(api_response)

--- a/docs/v1/Ontologies/ActionType.md
+++ b/docs/v1/Ontologies/ActionType.md
@@ -29,9 +29,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the action type.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -41,8 +39,7 @@ action_type_api_name = "promote-employee"
 
 try:
     api_response = foundry_client.ontologies.Ontology.ActionType.get(
-        ontology_rid,
-        action_type_api_name,
+        ontology_rid, action_type_api_name
     )
     print("The get response:\n")
     pprint(api_response)
@@ -91,9 +88,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the action types. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -104,10 +99,8 @@ page_token = None
 
 
 try:
-    for action_type in foundry_client.ontologies.Ontology.ActionType.list(
-        ontology_rid,
-        page_size=page_size,
-        page_token=page_token,
+    for action_type in client.ontologies.Ontology.ActionType.list(
+        ontology_rid, page_size=page_size, page_token=page_token
     ):
         pprint(action_type)
 except foundry.PalantirRPCException as e:
@@ -155,9 +148,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the action types. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -169,9 +160,7 @@ page_token = None
 
 try:
     api_response = foundry_client.ontologies.Ontology.ActionType.page(
-        ontology_rid,
-        page_size=page_size,
-        page_token=page_token,
+        ontology_rid, page_size=page_size, page_token=page_token
     )
     print("The page response:\n")
     pprint(api_response)

--- a/docs/v1/Ontologies/Attachment.md
+++ b/docs/v1/Ontologies/Attachment.md
@@ -29,18 +29,14 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AttachmentRid | The RID of the attachment.
 attachment_rid = "ri.attachments.main.attachment.bb32154e-e043-4b00-9461-93136ca96b6f"
 
 
 try:
-    api_response = foundry_client.ontologies.Attachment.get(
-        attachment_rid,
-    )
+    api_response = foundry_client.ontologies.Attachment.get(attachment_rid)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -84,18 +80,14 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AttachmentRid | The RID of the attachment.
 attachment_rid = "ri.attachments.main.attachment.bb32154e-e043-4b00-9461-93136ca96b6f"
 
 
 try:
-    api_response = foundry_client.ontologies.Attachment.read(
-        attachment_rid,
-    )
+    api_response = foundry_client.ontologies.Attachment.read(attachment_rid)
     print("The read response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -146,9 +138,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # bytes | Body of the request
 body = None
@@ -162,10 +152,7 @@ filename = "My Image.jpeg"
 
 try:
     api_response = foundry_client.ontologies.Attachment.upload(
-        body,
-        content_length=content_length,
-        content_type=content_type,
-        filename=filename,
+        body, content_length=content_length, content_type=content_type, filename=filename
     )
     print("The upload response:\n")
     pprint(api_response)

--- a/docs/v1/Ontologies/ObjectType.md
+++ b/docs/v1/Ontologies/ObjectType.md
@@ -32,9 +32,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the object type. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -43,10 +41,7 @@ object_type = "employee"
 
 
 try:
-    api_response = foundry_client.ontologies.Ontology.ObjectType.get(
-        ontology_rid,
-        object_type,
-    )
+    api_response = foundry_client.ontologies.Ontology.ObjectType.get(ontology_rid, object_type)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -92,9 +87,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the object type. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager** application.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -106,9 +99,7 @@ link_type = "directReport"
 
 try:
     api_response = foundry_client.ontologies.Ontology.ObjectType.get_outgoing_link_type(
-        ontology_rid,
-        object_type,
-        link_type,
+        ontology_rid, object_type, link_type
     )
     print("The get_outgoing_link_type response:\n")
     pprint(api_response)
@@ -158,9 +149,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the object types. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -171,10 +160,8 @@ page_token = None
 
 
 try:
-    for object_type in foundry_client.ontologies.Ontology.ObjectType.list(
-        ontology_rid,
-        page_size=page_size,
-        page_token=page_token,
+    for object_type in client.ontologies.Ontology.ObjectType.list(
+        ontology_rid, page_size=page_size, page_token=page_token
     ):
         pprint(object_type)
 except foundry.PalantirRPCException as e:
@@ -221,9 +208,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the object type. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager** application.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -236,11 +221,8 @@ page_token = None
 
 
 try:
-    for object_type in foundry_client.ontologies.Ontology.ObjectType.list_outgoing_link_types(
-        ontology_rid,
-        object_type,
-        page_size=page_size,
-        page_token=page_token,
+    for object_type in client.ontologies.Ontology.ObjectType.list_outgoing_link_types(
+        ontology_rid, object_type, page_size=page_size, page_token=page_token
     ):
         pprint(object_type)
 except foundry.PalantirRPCException as e:
@@ -289,9 +271,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the object types. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -303,9 +283,7 @@ page_token = None
 
 try:
     api_response = foundry_client.ontologies.Ontology.ObjectType.page(
-        ontology_rid,
-        page_size=page_size,
-        page_token=page_token,
+        ontology_rid, page_size=page_size, page_token=page_token
     )
     print("The page response:\n")
     pprint(api_response)
@@ -353,9 +331,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the object type. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager** application.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -369,10 +345,7 @@ page_token = None
 
 try:
     api_response = foundry_client.ontologies.Ontology.ObjectType.page_outgoing_link_types(
-        ontology_rid,
-        object_type,
-        page_size=page_size,
-        page_token=page_token,
+        ontology_rid, object_type, page_size=page_size, page_token=page_token
     )
     print("The page_outgoing_link_types response:\n")
     pprint(api_response)

--- a/docs/v1/Ontologies/Ontology.md
+++ b/docs/v1/Ontologies/Ontology.md
@@ -27,18 +27,14 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
 
 
 try:
-    api_response = foundry_client.ontologies.Ontology.get(
-        ontology_rid,
-    )
+    api_response = foundry_client.ontologies.Ontology.get(ontology_rid)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -80,9 +76,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 
 try:

--- a/docs/v1/Ontologies/OntologyObject.md
+++ b/docs/v1/Ontologies/OntologyObject.md
@@ -37,9 +37,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the objects.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -65,11 +63,7 @@ query = {"not": {"field": "properties.name", "eq": "john"}}
 
 try:
     api_response = foundry_client.ontologies.OntologyObject.aggregate(
-        ontology_rid,
-        object_type,
-        aggregation=aggregation,
-        group_by=group_by,
-        query=query,
+        ontology_rid, object_type, aggregation=aggregation, group_by=group_by, query=query
     )
     print("The aggregate response:\n")
     pprint(api_response)
@@ -116,9 +110,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the object. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -132,10 +124,7 @@ properties = None
 
 try:
     api_response = foundry_client.ontologies.OntologyObject.get(
-        ontology_rid,
-        object_type,
-        primary_key,
-        properties=properties,
+        ontology_rid, object_type, primary_key, properties=properties
     )
     print("The get response:\n")
     pprint(api_response)
@@ -185,9 +174,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the object. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -274,9 +261,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the objects. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -293,7 +278,7 @@ properties = None
 
 
 try:
-    for ontology_object in foundry_client.ontologies.OntologyObject.list(
+    for ontology_object in client.ontologies.OntologyObject.list(
         ontology_rid,
         object_type,
         order_by=order_by,
@@ -364,9 +349,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the objects. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -387,7 +370,7 @@ properties = None
 
 
 try:
-    for ontology_object in foundry_client.ontologies.OntologyObject.list_linked_objects(
+    for ontology_object in client.ontologies.OntologyObject.list_linked_objects(
         ontology_rid,
         object_type,
         primary_key,
@@ -458,9 +441,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the objects. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -549,9 +530,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the objects. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -651,9 +630,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the objects.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"

--- a/docs/v1/Ontologies/Query.md
+++ b/docs/v1/Ontologies/Query.md
@@ -28,9 +28,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the Query. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -42,9 +40,7 @@ parameters = {"city": "New York"}
 
 try:
     api_response = foundry_client.ontologies.Query.execute(
-        ontology_rid,
-        query_api_name,
-        parameters=parameters,
+        ontology_rid, query_api_name, parameters=parameters
     )
     print("The execute response:\n")
     pprint(api_response)

--- a/docs/v1/Ontologies/QueryType.md
+++ b/docs/v1/Ontologies/QueryType.md
@@ -29,9 +29,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the query type. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -40,10 +38,7 @@ query_api_name = "getEmployeesInCity"
 
 
 try:
-    api_response = foundry_client.ontologies.Ontology.QueryType.get(
-        ontology_rid,
-        query_api_name,
-    )
+    api_response = foundry_client.ontologies.Ontology.QueryType.get(ontology_rid, query_api_name)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -91,9 +86,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the query types. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -104,10 +97,8 @@ page_token = None
 
 
 try:
-    for query_type in foundry_client.ontologies.Ontology.QueryType.list(
-        ontology_rid,
-        page_size=page_size,
-        page_token=page_token,
+    for query_type in client.ontologies.Ontology.QueryType.list(
+        ontology_rid, page_size=page_size, page_token=page_token
     ):
         pprint(query_type)
 except foundry.PalantirRPCException as e:
@@ -155,9 +146,7 @@ from foundry.v1 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyRid | The unique Resource Identifier (RID) of the Ontology that contains the query types. To look up your Ontology RID, please use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology_rid = "ri.ontology.main.ontology.c61d9ab5-2919-4127-a0a1-ac64c0ce6367"
@@ -169,9 +158,7 @@ page_token = None
 
 try:
     api_response = foundry_client.ontologies.Ontology.QueryType.page(
-        ontology_rid,
-        page_size=page_size,
-        page_token=page_token,
+        ontology_rid, page_size=page_size, page_token=page_token
     )
     print("The page response:\n")
     pprint(api_response)

--- a/docs/v2/Admin/AuthenticationProvider.md
+++ b/docs/v2/Admin/AuthenticationProvider.md
@@ -28,9 +28,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # EnrollmentRid
 enrollment_rid = None
@@ -42,9 +40,7 @@ preview = None
 
 try:
     api_response = foundry_client.admin.Enrollment.AuthenticationProvider.get(
-        enrollment_rid,
-        authentication_provider_rid,
-        preview=preview,
+        enrollment_rid, authentication_provider_rid, preview=preview
     )
     print("The get response:\n")
     pprint(api_response)
@@ -88,9 +84,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # EnrollmentRid
 enrollment_rid = None
@@ -100,8 +94,7 @@ preview = None
 
 try:
     api_response = foundry_client.admin.Enrollment.AuthenticationProvider.list(
-        enrollment_rid,
-        preview=preview,
+        enrollment_rid, preview=preview
     )
     print("The list response:\n")
     pprint(api_response)
@@ -148,9 +141,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # EnrollmentRid
 enrollment_rid = None
@@ -221,9 +212,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # EnrollmentRid
 enrollment_rid = None

--- a/docs/v2/Admin/Enrollment.md
+++ b/docs/v2/Admin/Enrollment.md
@@ -25,9 +25,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # EnrollmentRid
 enrollment_rid = None
@@ -36,10 +34,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.admin.Enrollment.get(
-        enrollment_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.admin.Enrollment.get(enrollment_rid, preview=preview)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -80,18 +75,14 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Optional[PreviewMode] | Enables the use of preview functionality.
 preview = None
 
 
 try:
-    api_response = foundry_client.admin.Enrollment.get_current(
-        preview=preview,
-    )
+    api_response = foundry_client.admin.Enrollment.get_current(preview=preview)
     print("The get_current response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:

--- a/docs/v2/Admin/Group.md
+++ b/docs/v2/Admin/Group.md
@@ -32,9 +32,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Dict[AttributeName, AttributeValues] | A map of the Group's attributes. Attributes prefixed with "multipass:" are reserved for internal use by Foundry and are subject to change.
 attributes = {
@@ -58,10 +56,7 @@ description = "Create and modify data sources in the platform"
 
 try:
     api_response = foundry_client.admin.Group.create(
-        attributes=attributes,
-        name=name,
-        organizations=organizations,
-        description=description,
+        attributes=attributes, name=name, organizations=organizations, description=description
     )
     print("The create response:\n")
     pprint(api_response)
@@ -102,18 +97,14 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 group_id = None
 
 
 try:
-    api_response = foundry_client.admin.Group.delete(
-        group_id,
-    )
+    api_response = foundry_client.admin.Group.delete(group_id)
     print("The delete response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -153,18 +144,14 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 group_id = None
 
 
 try:
-    api_response = foundry_client.admin.Group.get(
-        group_id,
-    )
+    api_response = foundry_client.admin.Group.get(group_id)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -206,18 +193,14 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # List[Union[GetGroupsBatchRequestElement, GetGroupsBatchRequestElementDict]] | Body of the request
 body = [{"groupId": "f05f8da4-b84c-4fca-9c77-8af0b13d11de"}]
 
 
 try:
-    api_response = foundry_client.admin.Group.get_batch(
-        body,
-    )
+    api_response = foundry_client.admin.Group.get_batch(body)
     print("The get_batch response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -260,9 +243,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Optional[PageSize] | The page size to use for the endpoint.
 page_size = None
@@ -271,10 +252,7 @@ page_token = None
 
 
 try:
-    for group in foundry_client.admin.Group.list(
-        page_size=page_size,
-        page_token=page_token,
-    ):
+    for group in client.admin.Group.list(page_size=page_size, page_token=page_token):
         pprint(group)
 except foundry.PalantirRPCException as e:
     print("HTTP error when calling Group.list: %s\n" % e)
@@ -316,9 +294,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Optional[PageSize] | The page size to use for the endpoint.
 page_size = None
@@ -327,10 +303,7 @@ page_token = None
 
 
 try:
-    api_response = foundry_client.admin.Group.page(
-        page_size=page_size,
-        page_token=page_token,
-    )
+    api_response = foundry_client.admin.Group.page(page_size=page_size, page_token=page_token)
     print("The page response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -373,9 +346,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Union[GroupSearchFilter, GroupSearchFilterDict]
 where = {"type": "queryString"}
@@ -387,9 +358,7 @@ page_token = "v1.QnVpbGQgdGhlIEZ1dHVyZTogaHR0cHM6Ly93d3cucGFsYW50aXIuY29tL2NhcmV
 
 try:
     api_response = foundry_client.admin.Group.search(
-        where=where,
-        page_size=page_size,
-        page_token=page_token,
+        where=where, page_size=page_size, page_token=page_token
     )
     print("The search response:\n")
     pprint(api_response)

--- a/docs/v2/Admin/GroupMember.md
+++ b/docs/v2/Admin/GroupMember.md
@@ -28,9 +28,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 group_id = None
@@ -42,9 +40,7 @@ expiration = None
 
 try:
     api_response = foundry_client.admin.Group.GroupMember.add(
-        group_id,
-        principal_ids=principal_ids,
-        expiration=expiration,
+        group_id, principal_ids=principal_ids, expiration=expiration
     )
     print("The add response:\n")
     pprint(api_response)
@@ -95,9 +91,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 group_id = None
@@ -110,11 +104,8 @@ transitive = None
 
 
 try:
-    for group_member in foundry_client.admin.Group.GroupMember.list(
-        group_id,
-        page_size=page_size,
-        page_token=page_token,
-        transitive=transitive,
+    for group_member in client.admin.Group.GroupMember.list(
+        group_id, page_size=page_size, page_token=page_token, transitive=transitive
     ):
         pprint(group_member)
 except foundry.PalantirRPCException as e:
@@ -164,9 +155,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 group_id = None
@@ -180,10 +169,7 @@ transitive = None
 
 try:
     api_response = foundry_client.admin.Group.GroupMember.page(
-        group_id,
-        page_size=page_size,
-        page_token=page_token,
-        transitive=transitive,
+        group_id, page_size=page_size, page_token=page_token, transitive=transitive
     )
     print("The page response:\n")
     pprint(api_response)
@@ -225,9 +211,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 group_id = None
@@ -237,8 +221,7 @@ principal_ids = ["f05f8da4-b84c-4fca-9c77-8af0b13d11de"]
 
 try:
     api_response = foundry_client.admin.Group.GroupMember.remove(
-        group_id,
-        principal_ids=principal_ids,
+        group_id, principal_ids=principal_ids
     )
     print("The remove response:\n")
     pprint(api_response)

--- a/docs/v2/Admin/GroupMembership.md
+++ b/docs/v2/Admin/GroupMembership.md
@@ -34,9 +34,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 user_id = None
@@ -49,11 +47,8 @@ transitive = None
 
 
 try:
-    for group_membership in foundry_client.admin.User.GroupMembership.list(
-        user_id,
-        page_size=page_size,
-        page_token=page_token,
-        transitive=transitive,
+    for group_membership in client.admin.User.GroupMembership.list(
+        user_id, page_size=page_size, page_token=page_token, transitive=transitive
     ):
         pprint(group_membership)
 except foundry.PalantirRPCException as e:
@@ -103,9 +98,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 user_id = None
@@ -119,10 +112,7 @@ transitive = None
 
 try:
     api_response = foundry_client.admin.User.GroupMembership.page(
-        user_id,
-        page_size=page_size,
-        page_token=page_token,
-        transitive=transitive,
+        user_id, page_size=page_size, page_token=page_token, transitive=transitive
     )
     print("The page response:\n")
     pprint(api_response)

--- a/docs/v2/Admin/GroupProviderInfo.md
+++ b/docs/v2/Admin/GroupProviderInfo.md
@@ -25,9 +25,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 group_id = None
@@ -36,10 +34,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.admin.Group.ProviderInfo.get(
-        group_id,
-        preview=preview,
-    )
+    api_response = foundry_client.admin.Group.ProviderInfo.get(group_id, preview=preview)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -81,9 +76,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 group_id = None
@@ -95,9 +88,7 @@ preview = None
 
 try:
     api_response = foundry_client.admin.Group.ProviderInfo.replace(
-        group_id,
-        provider_id=provider_id,
-        preview=preview,
+        group_id, provider_id=provider_id, preview=preview
     )
     print("The replace response:\n")
     pprint(api_response)

--- a/docs/v2/Admin/Host.md
+++ b/docs/v2/Admin/Host.md
@@ -29,9 +29,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # EnrollmentRid
 enrollment_rid = None
@@ -44,11 +42,8 @@ preview = None
 
 
 try:
-    for host in foundry_client.admin.Enrollment.Host.list(
-        enrollment_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for host in client.admin.Enrollment.Host.list(
+        enrollment_rid, page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(host)
 except foundry.PalantirRPCException as e:
@@ -93,9 +88,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # EnrollmentRid
 enrollment_rid = None
@@ -109,10 +102,7 @@ preview = None
 
 try:
     api_response = foundry_client.admin.Enrollment.Host.page(
-        enrollment_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        enrollment_rid, page_size=page_size, page_token=page_token, preview=preview
     )
     print("The page response:\n")
     pprint(api_response)

--- a/docs/v2/Admin/Marking.md
+++ b/docs/v2/Admin/Marking.md
@@ -32,9 +32,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MarkingCategoryId
 category_id = "0950264e-01c8-4e83-81a9-1a6b7f77621a"
@@ -101,9 +99,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MarkingId
 marking_id = None
@@ -112,10 +108,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.admin.Marking.get(
-        marking_id,
-        preview=preview,
-    )
+    api_response = foundry_client.admin.Marking.get(marking_id, preview=preview)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -158,9 +151,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # List[Union[GetMarkingsBatchRequestElement, GetMarkingsBatchRequestElementDict]] | Body of the request
 body = [{"markingId": "18212f9a-0e63-4b79-96a0-aae04df23336"}]
@@ -169,10 +160,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.admin.Marking.get_batch(
-        body,
-        preview=preview,
-    )
+    api_response = foundry_client.admin.Marking.get_batch(body, preview=preview)
     print("The get_batch response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -214,9 +202,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Optional[PageSize] | The page size to use for the endpoint.
 page_size = None
@@ -227,10 +213,8 @@ preview = None
 
 
 try:
-    for marking in foundry_client.admin.Marking.list(
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for marking in client.admin.Marking.list(
+        page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(marking)
 except foundry.PalantirRPCException as e:
@@ -272,9 +256,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Optional[PageSize] | The page size to use for the endpoint.
 page_size = None
@@ -286,9 +268,7 @@ preview = None
 
 try:
     api_response = foundry_client.admin.Marking.page(
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        page_size=page_size, page_token=page_token, preview=preview
     )
     print("The page response:\n")
     pprint(api_response)

--- a/docs/v2/Admin/MarkingCategory.md
+++ b/docs/v2/Admin/MarkingCategory.md
@@ -26,9 +26,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MarkingCategoryId
 marking_category_id = None
@@ -37,10 +35,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.admin.MarkingCategory.get(
-        marking_category_id,
-        preview=preview,
-    )
+    api_response = foundry_client.admin.MarkingCategory.get(marking_category_id, preview=preview)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -82,9 +77,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Optional[PageSize] | The page size to use for the endpoint.
 page_size = None
@@ -95,10 +88,8 @@ preview = None
 
 
 try:
-    for marking_category in foundry_client.admin.MarkingCategory.list(
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for marking_category in client.admin.MarkingCategory.list(
+        page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(marking_category)
 except foundry.PalantirRPCException as e:
@@ -140,9 +131,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Optional[PageSize] | The page size to use for the endpoint.
 page_size = None
@@ -154,9 +143,7 @@ preview = None
 
 try:
     api_response = foundry_client.admin.MarkingCategory.page(
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        page_size=page_size, page_token=page_token, preview=preview
     )
     print("The page response:\n")
     pprint(api_response)

--- a/docs/v2/Admin/MarkingMember.md
+++ b/docs/v2/Admin/MarkingMember.md
@@ -28,9 +28,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MarkingId
 marking_id = None
@@ -42,9 +40,7 @@ preview = None
 
 try:
     api_response = foundry_client.admin.Marking.MarkingMember.add(
-        marking_id,
-        principal_ids=principal_ids,
-        preview=preview,
+        marking_id, principal_ids=principal_ids, preview=preview
     )
     print("The add response:\n")
     pprint(api_response)
@@ -91,9 +87,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MarkingId
 marking_id = None
@@ -108,7 +102,7 @@ transitive = None
 
 
 try:
-    for marking_member in foundry_client.admin.Marking.MarkingMember.list(
+    for marking_member in client.admin.Marking.MarkingMember.list(
         marking_id,
         page_size=page_size,
         page_token=page_token,
@@ -159,9 +153,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MarkingId
 marking_id = None
@@ -224,9 +216,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MarkingId
 marking_id = None
@@ -238,9 +228,7 @@ preview = None
 
 try:
     api_response = foundry_client.admin.Marking.MarkingMember.remove(
-        marking_id,
-        principal_ids=principal_ids,
-        preview=preview,
+        marking_id, principal_ids=principal_ids, preview=preview
     )
     print("The remove response:\n")
     pprint(api_response)

--- a/docs/v2/Admin/MarkingRoleAssignment.md
+++ b/docs/v2/Admin/MarkingRoleAssignment.md
@@ -28,9 +28,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MarkingId
 marking_id = None
@@ -42,9 +40,7 @@ preview = None
 
 try:
     api_response = foundry_client.admin.Marking.MarkingRoleAssignment.add(
-        marking_id,
-        role_assignments=role_assignments,
-        preview=preview,
+        marking_id, role_assignments=role_assignments, preview=preview
     )
     print("The add response:\n")
     pprint(api_response)
@@ -89,9 +85,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MarkingId
 marking_id = None
@@ -104,11 +98,8 @@ preview = None
 
 
 try:
-    for marking_role_assignment in foundry_client.admin.Marking.MarkingRoleAssignment.list(
-        marking_id,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for marking_role_assignment in client.admin.Marking.MarkingRoleAssignment.list(
+        marking_id, page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(marking_role_assignment)
 except foundry.PalantirRPCException as e:
@@ -152,9 +143,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MarkingId
 marking_id = None
@@ -168,10 +157,7 @@ preview = None
 
 try:
     api_response = foundry_client.admin.Marking.MarkingRoleAssignment.page(
-        marking_id,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        marking_id, page_size=page_size, page_token=page_token, preview=preview
     )
     print("The page response:\n")
     pprint(api_response)
@@ -214,9 +200,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MarkingId
 marking_id = None
@@ -228,9 +212,7 @@ preview = None
 
 try:
     api_response = foundry_client.admin.Marking.MarkingRoleAssignment.remove(
-        marking_id,
-        role_assignments=role_assignments,
-        preview=preview,
+        marking_id, role_assignments=role_assignments, preview=preview
     )
     print("The remove response:\n")
     pprint(api_response)

--- a/docs/v2/Admin/Organization.md
+++ b/docs/v2/Admin/Organization.md
@@ -25,9 +25,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OrganizationRid
 organization_rid = None
@@ -36,10 +34,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.admin.Organization.get(
-        organization_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.admin.Organization.get(organization_rid, preview=preview)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -83,9 +78,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OrganizationRid
 organization_rid = None
@@ -101,11 +94,7 @@ preview = None
 
 try:
     api_response = foundry_client.admin.Organization.replace(
-        organization_rid,
-        name=name,
-        description=description,
-        host=host,
-        preview=preview,
+        organization_rid, name=name, description=description, host=host, preview=preview
     )
     print("The replace response:\n")
     pprint(api_response)

--- a/docs/v2/Admin/User.md
+++ b/docs/v2/Admin/User.md
@@ -31,18 +31,14 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 user_id = None
 
 
 try:
-    api_response = foundry_client.admin.User.delete(
-        user_id,
-    )
+    api_response = foundry_client.admin.User.delete(user_id)
     print("The delete response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -82,18 +78,14 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 user_id = None
 
 
 try:
-    api_response = foundry_client.admin.User.get(
-        user_id,
-    )
+    api_response = foundry_client.admin.User.get(user_id)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -135,18 +127,14 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # List[Union[GetUsersBatchRequestElement, GetUsersBatchRequestElementDict]] | Body of the request
 body = [{"userId": "f05f8da4-b84c-4fca-9c77-8af0b13d11de"}]
 
 
 try:
-    api_response = foundry_client.admin.User.get_batch(
-        body,
-    )
+    api_response = foundry_client.admin.User.get_batch(body)
     print("The get_batch response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -185,9 +173,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 
 try:
@@ -232,9 +218,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 user_id = None
@@ -243,10 +227,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.admin.User.get_markings(
-        user_id,
-        preview=preview,
-    )
+    api_response = foundry_client.admin.User.get_markings(user_id, preview=preview)
     print("The get_markings response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -289,9 +270,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Optional[PageSize] | The page size to use for the endpoint.
 page_size = None
@@ -300,10 +279,7 @@ page_token = None
 
 
 try:
-    for user in foundry_client.admin.User.list(
-        page_size=page_size,
-        page_token=page_token,
-    ):
+    for user in client.admin.User.list(page_size=page_size, page_token=page_token):
         pprint(user)
 except foundry.PalantirRPCException as e:
     print("HTTP error when calling User.list: %s\n" % e)
@@ -345,9 +321,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Optional[PageSize] | The page size to use for the endpoint.
 page_size = None
@@ -356,10 +330,7 @@ page_token = None
 
 
 try:
-    api_response = foundry_client.admin.User.page(
-        page_size=page_size,
-        page_token=page_token,
-    )
+    api_response = foundry_client.admin.User.page(page_size=page_size, page_token=page_token)
     print("The page response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -399,18 +370,14 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 user_id = None
 
 
 try:
-    api_response = foundry_client.admin.User.profile_picture(
-        user_id,
-    )
+    api_response = foundry_client.admin.User.profile_picture(user_id)
     print("The profile_picture response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -453,9 +420,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Union[UserSearchFilter, UserSearchFilterDict]
 where = {"type": "queryString"}
@@ -467,9 +432,7 @@ page_token = "v1.QnVpbGQgdGhlIEZ1dHVyZTogaHR0cHM6Ly93d3cucGFsYW50aXIuY29tL2NhcmV
 
 try:
     api_response = foundry_client.admin.User.search(
-        where=where,
-        page_size=page_size,
-        page_token=page_token,
+        where=where, page_size=page_size, page_token=page_token
     )
     print("The search response:\n")
     pprint(api_response)

--- a/docs/v2/Admin/UserProviderInfo.md
+++ b/docs/v2/Admin/UserProviderInfo.md
@@ -25,9 +25,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 user_id = None
@@ -36,10 +34,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.admin.User.ProviderInfo.get(
-        user_id,
-        preview=preview,
-    )
+    api_response = foundry_client.admin.User.ProviderInfo.get(user_id, preview=preview)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -81,9 +76,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # PrincipalId
 user_id = None
@@ -95,9 +88,7 @@ preview = None
 
 try:
     api_response = foundry_client.admin.User.ProviderInfo.replace(
-        user_id,
-        provider_id=provider_id,
-        preview=preview,
+        user_id, provider_id=provider_id, preview=preview
     )
     print("The replace response:\n")
     pprint(api_response)

--- a/docs/v2/AipAgents/Agent.md
+++ b/docs/v2/AipAgents/Agent.md
@@ -29,9 +29,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Optional[PageSize] | The maximum number of sessions to return in a single page. The maximum allowed value is 100. Defaults to 100 if not specified.
 page_size = None
@@ -42,10 +40,8 @@ preview = None
 
 
 try:
-    for agent in foundry_client.aip_agents.Agent.all_sessions(
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for agent in client.aip_agents.Agent.all_sessions(
+        page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(agent)
 except foundry.PalantirRPCException as e:
@@ -89,9 +85,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Optional[PageSize] | The maximum number of sessions to return in a single page. The maximum allowed value is 100. Defaults to 100 if not specified.
 page_size = None
@@ -103,9 +97,7 @@ preview = None
 
 try:
     api_response = foundry_client.aip_agents.Agent.all_sessions_page(
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        page_size=page_size, page_token=page_token, preview=preview
     )
     print("The all_sessions_page response:\n")
     pprint(api_response)
@@ -148,9 +140,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AgentRid | An RID identifying an AIP Agent created in [AIP Agent Studio](/docs/foundry/agent-studio/overview/).
 agent_rid = "ri.aip-agents..agent.732cd5b4-7ca7-4219-aabb-6e976faf63b1"
@@ -161,11 +151,7 @@ version = None
 
 
 try:
-    api_response = foundry_client.aip_agents.Agent.get(
-        agent_rid,
-        preview=preview,
-        version=version,
-    )
+    api_response = foundry_client.aip_agents.Agent.get(agent_rid, preview=preview, version=version)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:

--- a/docs/v2/AipAgents/AgentVersion.md
+++ b/docs/v2/AipAgents/AgentVersion.md
@@ -27,9 +27,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AgentRid | An RID identifying an AIP Agent created in [AIP Agent Studio](/docs/foundry/agent-studio/overview/).
 agent_rid = "ri.aip-agents..agent.732cd5b4-7ca7-4219-aabb-6e976faf63b1"
@@ -41,9 +39,7 @@ preview = None
 
 try:
     api_response = foundry_client.aip_agents.Agent.AgentVersion.get(
-        agent_rid,
-        agent_version_string,
-        preview=preview,
+        agent_rid, agent_version_string, preview=preview
     )
     print("The get response:\n")
     pprint(api_response)
@@ -89,9 +85,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AgentRid | An RID identifying an AIP Agent created in [AIP Agent Studio](/docs/foundry/agent-studio/overview/).
 agent_rid = "ri.aip-agents..agent.732cd5b4-7ca7-4219-aabb-6e976faf63b1"
@@ -104,11 +98,8 @@ preview = None
 
 
 try:
-    for agent_version in foundry_client.aip_agents.Agent.AgentVersion.list(
-        agent_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for agent_version in client.aip_agents.Agent.AgentVersion.list(
+        agent_rid, page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(agent_version)
 except foundry.PalantirRPCException as e:
@@ -153,9 +144,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AgentRid | An RID identifying an AIP Agent created in [AIP Agent Studio](/docs/foundry/agent-studio/overview/).
 agent_rid = "ri.aip-agents..agent.732cd5b4-7ca7-4219-aabb-6e976faf63b1"
@@ -169,10 +158,7 @@ preview = None
 
 try:
     api_response = foundry_client.aip_agents.Agent.AgentVersion.page(
-        agent_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        agent_rid, page_size=page_size, page_token=page_token, preview=preview
     )
     print("The page response:\n")
     pprint(api_response)

--- a/docs/v2/AipAgents/Content.md
+++ b/docs/v2/AipAgents/Content.md
@@ -25,9 +25,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AgentRid | An RID identifying an AIP Agent created in [AIP Agent Studio](/docs/foundry/agent-studio/overview/).
 agent_rid = "ri.aip-agents..agent.732cd5b4-7ca7-4219-aabb-6e976faf63b1"
@@ -39,9 +37,7 @@ preview = None
 
 try:
     api_response = foundry_client.aip_agents.Agent.Session.Content.get(
-        agent_rid,
-        session_rid,
-        preview=preview,
+        agent_rid, session_rid, preview=preview
     )
     print("The get response:\n")
     pprint(api_response)

--- a/docs/v2/AipAgents/Session.md
+++ b/docs/v2/AipAgents/Session.md
@@ -42,9 +42,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AgentRid | An RID identifying an AIP Agent created in [AIP Agent Studio](/docs/foundry/agent-studio/overview/).
 agent_rid = "ri.aip-agents..agent.732cd5b4-7ca7-4219-aabb-6e976faf63b1"
@@ -125,9 +123,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AgentRid | An RID identifying an AIP Agent created in [AIP Agent Studio](/docs/foundry/agent-studio/overview/).
 agent_rid = "ri.aip-agents..agent.732cd5b4-7ca7-4219-aabb-6e976faf63b1"
@@ -143,11 +139,7 @@ response = "The status of your order is **In Transit**."
 
 try:
     api_response = foundry_client.aip_agents.Agent.Session.cancel(
-        agent_rid,
-        session_rid,
-        message_id=message_id,
-        preview=preview,
-        response=response,
+        agent_rid, session_rid, message_id=message_id, preview=preview, response=response
     )
     print("The cancel response:\n")
     pprint(api_response)
@@ -192,9 +184,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AgentRid | An RID identifying an AIP Agent created in [AIP Agent Studio](/docs/foundry/agent-studio/overview/).
 agent_rid = "ri.aip-agents..agent.732cd5b4-7ca7-4219-aabb-6e976faf63b1"
@@ -206,9 +196,7 @@ preview = None
 
 try:
     api_response = foundry_client.aip_agents.Agent.Session.create(
-        agent_rid,
-        agent_version=agent_version,
-        preview=preview,
+        agent_rid, agent_version=agent_version, preview=preview
     )
     print("The create response:\n")
     pprint(api_response)
@@ -251,9 +239,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AgentRid | An RID identifying an AIP Agent created in [AIP Agent Studio](/docs/foundry/agent-studio/overview/).
 agent_rid = "ri.aip-agents..agent.732cd5b4-7ca7-4219-aabb-6e976faf63b1"
@@ -265,9 +251,7 @@ preview = None
 
 try:
     api_response = foundry_client.aip_agents.Agent.Session.get(
-        agent_rid,
-        session_rid,
-        preview=preview,
+        agent_rid, session_rid, preview=preview
     )
     print("The get response:\n")
     pprint(api_response)
@@ -315,9 +299,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AgentRid | An RID identifying an AIP Agent created in [AIP Agent Studio](/docs/foundry/agent-studio/overview/).
 agent_rid = "ri.aip-agents..agent.732cd5b4-7ca7-4219-aabb-6e976faf63b1"
@@ -330,11 +312,8 @@ preview = None
 
 
 try:
-    for session in foundry_client.aip_agents.Agent.Session.list(
-        agent_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for session in client.aip_agents.Agent.Session.list(
+        agent_rid, page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(session)
 except foundry.PalantirRPCException as e:
@@ -381,9 +360,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AgentRid | An RID identifying an AIP Agent created in [AIP Agent Studio](/docs/foundry/agent-studio/overview/).
 agent_rid = "ri.aip-agents..agent.732cd5b4-7ca7-4219-aabb-6e976faf63b1"
@@ -397,10 +374,7 @@ preview = None
 
 try:
     api_response = foundry_client.aip_agents.Agent.Session.page(
-        agent_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        agent_rid, page_size=page_size, page_token=page_token, preview=preview
     )
     print("The page response:\n")
     pprint(api_response)
@@ -447,9 +421,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AgentRid | An RID identifying an AIP Agent created in [AIP Agent Studio](/docs/foundry/agent-studio/overview/).
 agent_rid = "ri.aip-agents..agent.732cd5b4-7ca7-4219-aabb-6e976faf63b1"
@@ -523,9 +495,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AgentRid | An RID identifying an AIP Agent created in [AIP Agent Studio](/docs/foundry/agent-studio/overview/).
 agent_rid = "ri.aip-agents..agent.732cd5b4-7ca7-4219-aabb-6e976faf63b1"
@@ -607,9 +577,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AgentRid | An RID identifying an AIP Agent created in [AIP Agent Studio](/docs/foundry/agent-studio/overview/).
 agent_rid = "ri.aip-agents..agent.732cd5b4-7ca7-4219-aabb-6e976faf63b1"
@@ -623,10 +591,7 @@ preview = None
 
 try:
     api_response = foundry_client.aip_agents.Agent.Session.update_title(
-        agent_rid,
-        session_rid,
-        title=title,
-        preview=preview,
+        agent_rid, session_rid, title=title, preview=preview
     )
     print("The update_title response:\n")
     pprint(api_response)

--- a/docs/v2/Connectivity/Connection.md
+++ b/docs/v2/Connectivity/Connection.md
@@ -38,9 +38,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Union[CreateConnectionRequestConnectionConfiguration, CreateConnectionRequestConnectionConfigurationDict]
 configuration = None
@@ -99,9 +97,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None
@@ -110,10 +106,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.connectivity.Connection.get(
-        connection_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.connectivity.Connection.get(connection_rid, preview=preview)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -156,9 +149,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None
@@ -168,8 +159,7 @@ preview = None
 
 try:
     api_response = foundry_client.connectivity.Connection.get_configuration(
-        connection_rid,
-        preview=preview,
+        connection_rid, preview=preview
     )
     print("The get_configuration response:\n")
     pprint(api_response)
@@ -223,9 +213,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None
@@ -237,9 +225,7 @@ preview = None
 
 try:
     api_response = foundry_client.connectivity.Connection.update_secrets(
-        connection_rid,
-        secrets=secrets,
-        preview=preview,
+        connection_rid, secrets=secrets, preview=preview
     )
     print("The update_secrets response:\n")
     pprint(api_response)

--- a/docs/v2/Connectivity/FileImport.md
+++ b/docs/v2/Connectivity/FileImport.md
@@ -36,9 +36,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None
@@ -113,9 +111,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None
@@ -127,9 +123,7 @@ preview = None
 
 try:
     api_response = foundry_client.connectivity.Connection.FileImport.delete(
-        connection_rid,
-        file_import_rid,
-        preview=preview,
+        connection_rid, file_import_rid, preview=preview
     )
     print("The delete response:\n")
     pprint(api_response)
@@ -174,9 +168,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None
@@ -188,9 +180,7 @@ preview = None
 
 try:
     api_response = foundry_client.connectivity.Connection.FileImport.execute(
-        connection_rid,
-        file_import_rid,
-        preview=preview,
+        connection_rid, file_import_rid, preview=preview
     )
     print("The execute response:\n")
     pprint(api_response)
@@ -233,9 +223,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None
@@ -247,9 +235,7 @@ preview = None
 
 try:
     api_response = foundry_client.connectivity.Connection.FileImport.get(
-        connection_rid,
-        file_import_rid,
-        preview=preview,
+        connection_rid, file_import_rid, preview=preview
     )
     print("The get response:\n")
     pprint(api_response)
@@ -295,9 +281,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None
@@ -310,11 +294,8 @@ preview = None
 
 
 try:
-    for file_import in foundry_client.connectivity.Connection.FileImport.list(
-        connection_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for file_import in client.connectivity.Connection.FileImport.list(
+        connection_rid, page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(file_import)
 except foundry.PalantirRPCException as e:
@@ -359,9 +340,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None
@@ -375,10 +354,7 @@ preview = None
 
 try:
     api_response = foundry_client.connectivity.Connection.FileImport.page(
-        connection_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        connection_rid, page_size=page_size, page_token=page_token, preview=preview
     )
     print("The page response:\n")
     pprint(api_response)
@@ -427,9 +403,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None

--- a/docs/v2/Connectivity/TableImport.md
+++ b/docs/v2/Connectivity/TableImport.md
@@ -35,9 +35,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None
@@ -112,9 +110,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None
@@ -126,9 +122,7 @@ preview = None
 
 try:
     api_response = foundry_client.connectivity.Connection.TableImport.delete(
-        connection_rid,
-        table_import_rid,
-        preview=preview,
+        connection_rid, table_import_rid, preview=preview
     )
     print("The delete response:\n")
     pprint(api_response)
@@ -173,9 +167,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None
@@ -187,9 +179,7 @@ preview = None
 
 try:
     api_response = foundry_client.connectivity.Connection.TableImport.execute(
-        connection_rid,
-        table_import_rid,
-        preview=preview,
+        connection_rid, table_import_rid, preview=preview
     )
     print("The execute response:\n")
     pprint(api_response)
@@ -232,9 +222,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None
@@ -246,9 +234,7 @@ preview = None
 
 try:
     api_response = foundry_client.connectivity.Connection.TableImport.get(
-        connection_rid,
-        table_import_rid,
-        preview=preview,
+        connection_rid, table_import_rid, preview=preview
     )
     print("The get response:\n")
     pprint(api_response)
@@ -294,9 +280,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None
@@ -309,11 +293,8 @@ preview = None
 
 
 try:
-    for table_import in foundry_client.connectivity.Connection.TableImport.list(
-        connection_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for table_import in client.connectivity.Connection.TableImport.list(
+        connection_rid, page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(table_import)
 except foundry.PalantirRPCException as e:
@@ -358,9 +339,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ConnectionRid
 connection_rid = None
@@ -374,10 +353,7 @@ preview = None
 
 try:
     api_response = foundry_client.connectivity.Connection.TableImport.page(
-        connection_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        connection_rid, page_size=page_size, page_token=page_token, preview=preview
     )
     print("The page response:\n")
     pprint(api_response)

--- a/docs/v2/Datasets/Branch.md
+++ b/docs/v2/Datasets/Branch.md
@@ -30,9 +30,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -44,9 +42,7 @@ transaction_rid = "ri.foundry.main.transaction.0a0207cb-26b7-415b-bc80-66a3aa393
 
 try:
     api_response = foundry_client.datasets.Dataset.Branch.create(
-        dataset_rid,
-        name=name,
-        transaction_rid=transaction_rid,
+        dataset_rid, name=name, transaction_rid=transaction_rid
     )
     print("The create response:\n")
     pprint(api_response)
@@ -89,9 +85,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -100,10 +94,7 @@ branch_name = None
 
 
 try:
-    api_response = foundry_client.datasets.Dataset.Branch.delete(
-        dataset_rid,
-        branch_name,
-    )
+    api_response = foundry_client.datasets.Dataset.Branch.delete(dataset_rid, branch_name)
     print("The delete response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -145,9 +136,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -156,10 +145,7 @@ branch_name = None
 
 
 try:
-    api_response = foundry_client.datasets.Dataset.Branch.get(
-        dataset_rid,
-        branch_name,
-    )
+    api_response = foundry_client.datasets.Dataset.Branch.get(dataset_rid, branch_name)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -202,9 +188,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -215,10 +199,8 @@ page_token = None
 
 
 try:
-    for branch in foundry_client.datasets.Dataset.Branch.list(
-        dataset_rid,
-        page_size=page_size,
-        page_token=page_token,
+    for branch in client.datasets.Dataset.Branch.list(
+        dataset_rid, page_size=page_size, page_token=page_token
     ):
         pprint(branch)
 except foundry.PalantirRPCException as e:
@@ -261,9 +243,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -275,9 +255,7 @@ page_token = None
 
 try:
     api_response = foundry_client.datasets.Dataset.Branch.page(
-        dataset_rid,
-        page_size=page_size,
-        page_token=page_token,
+        dataset_rid, page_size=page_size, page_token=page_token
     )
     print("The page response:\n")
     pprint(api_response)

--- a/docs/v2/Datasets/Dataset.md
+++ b/docs/v2/Datasets/Dataset.md
@@ -27,9 +27,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetName
 name = "My Dataset"
@@ -39,8 +37,7 @@ parent_folder_rid = "ri.compass.main.folder.c410f510-2937-420e-8ea3-8c9bcb3c1791
 
 try:
     api_response = foundry_client.datasets.Dataset.create(
-        name=name,
-        parent_folder_rid=parent_folder_rid,
+        name=name, parent_folder_rid=parent_folder_rid
     )
     print("The create response:\n")
     pprint(api_response)
@@ -81,18 +78,14 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
 
 
 try:
-    api_response = foundry_client.datasets.Dataset.get(
-        dataset_rid,
-    )
+    api_response = foundry_client.datasets.Dataset.get(dataset_rid)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -141,9 +134,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None

--- a/docs/v2/Datasets/File.md
+++ b/docs/v2/Datasets/File.md
@@ -49,9 +49,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -125,9 +123,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -141,10 +137,7 @@ transaction_rid = None
 
 try:
     api_response = foundry_client.datasets.Dataset.File.delete(
-        dataset_rid,
-        file_path,
-        branch_name=branch_name,
-        transaction_rid=transaction_rid,
+        dataset_rid, file_path, branch_name=branch_name, transaction_rid=transaction_rid
     )
     print("The delete response:\n")
     pprint(api_response)
@@ -205,9 +198,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -291,9 +282,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -310,7 +299,7 @@ start_transaction_rid = None
 
 
 try:
-    for file in foundry_client.datasets.Dataset.File.list(
+    for file in client.datasets.Dataset.File.list(
         dataset_rid,
         branch_name=branch_name,
         end_transaction_rid=end_transaction_rid,
@@ -379,9 +368,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -463,9 +450,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None

--- a/docs/v2/Datasets/Transaction.md
+++ b/docs/v2/Datasets/Transaction.md
@@ -31,9 +31,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -42,10 +40,7 @@ transaction_rid = None
 
 
 try:
-    api_response = foundry_client.datasets.Dataset.Transaction.abort(
-        dataset_rid,
-        transaction_rid,
-    )
+    api_response = foundry_client.datasets.Dataset.Transaction.abort(dataset_rid, transaction_rid)
     print("The abort response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -90,9 +85,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -104,9 +97,7 @@ preview = None
 
 try:
     api_response = foundry_client.datasets.Dataset.Transaction.build(
-        dataset_rid,
-        transaction_rid,
-        preview=preview,
+        dataset_rid, transaction_rid, preview=preview
     )
     print("The build response:\n")
     pprint(api_response)
@@ -150,9 +141,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -161,10 +150,7 @@ transaction_rid = None
 
 
 try:
-    api_response = foundry_client.datasets.Dataset.Transaction.commit(
-        dataset_rid,
-        transaction_rid,
-    )
+    api_response = foundry_client.datasets.Dataset.Transaction.commit(dataset_rid, transaction_rid)
     print("The commit response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -207,9 +193,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -221,9 +205,7 @@ branch_name = None
 
 try:
     api_response = foundry_client.datasets.Dataset.Transaction.create(
-        dataset_rid,
-        transaction_type=transaction_type,
-        branch_name=branch_name,
+        dataset_rid, transaction_type=transaction_type, branch_name=branch_name
     )
     print("The create response:\n")
     pprint(api_response)
@@ -288,9 +270,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -299,10 +279,7 @@ transaction_rid = None
 
 
 try:
-    api_response = foundry_client.datasets.Dataset.Transaction.get(
-        dataset_rid,
-        transaction_rid,
-    )
+    api_response = foundry_client.datasets.Dataset.Transaction.get(dataset_rid, transaction_rid)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -347,9 +324,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -361,9 +336,7 @@ preview = None
 
 try:
     api_response = foundry_client.datasets.Dataset.Transaction.job(
-        dataset_rid,
-        transaction_rid,
-        preview=preview,
+        dataset_rid, transaction_rid, preview=preview
     )
     print("The job response:\n")
     pprint(api_response)

--- a/docs/v2/Filesystem/Folder.md
+++ b/docs/v2/Filesystem/Folder.md
@@ -33,9 +33,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # FolderRid
 folder_rid = "ri.compass.main.folder.01a79a9d-e293-48db-a585-9ffe221536e8"
@@ -48,11 +46,8 @@ preview = None
 
 
 try:
-    for folder in foundry_client.filesystem.Folder.children(
-        folder_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for folder in client.filesystem.Folder.children(
+        folder_rid, page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(folder)
 except foundry.PalantirRPCException as e:
@@ -99,9 +94,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # FolderRid
 folder_rid = "ri.compass.main.folder.01a79a9d-e293-48db-a585-9ffe221536e8"
@@ -115,10 +108,7 @@ preview = None
 
 try:
     api_response = foundry_client.filesystem.Folder.children_page(
-        folder_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        folder_rid, page_size=page_size, page_token=page_token, preview=preview
     )
     print("The children_page response:\n")
     pprint(api_response)
@@ -161,9 +151,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ResourceDisplayName
 display_name = "My Folder"
@@ -175,9 +163,7 @@ preview = None
 
 try:
     api_response = foundry_client.filesystem.Folder.create(
-        display_name=display_name,
-        parent_folder_rid=parent_folder_rid,
-        preview=preview,
+        display_name=display_name, parent_folder_rid=parent_folder_rid, preview=preview
     )
     print("The create response:\n")
     pprint(api_response)
@@ -219,9 +205,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # FolderRid
 folder_rid = "ri.compass.main.folder.01a79a9d-e293-48db-a585-9ffe221536e8"
@@ -230,10 +214,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.filesystem.Folder.get(
-        folder_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.filesystem.Folder.get(folder_rid, preview=preview)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:

--- a/docs/v2/Filesystem/Project.md
+++ b/docs/v2/Filesystem/Project.md
@@ -31,9 +31,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ProjectRid
 project_rid = "ri.compass.main.folder.01a79a9d-e293-48db-a585-9ffe221536e8"
@@ -45,9 +43,7 @@ preview = None
 
 try:
     api_response = foundry_client.filesystem.Project.add_organizations(
-        project_rid,
-        organization_rids=organization_rids,
-        preview=preview,
+        project_rid, organization_rids=organization_rids, preview=preview
     )
     print("The add_organizations response:\n")
     pprint(api_response)
@@ -99,9 +95,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # List[RoleId]
 default_roles = ["8bf49052-dc37-4528-8bf0-b551cfb71268"]
@@ -177,9 +171,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ProjectTemplateRid
 template_rid = "ri.compass.main.template.c410f510-2937-420e-8ea3-8c9bcb3c1791"
@@ -244,9 +236,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ProjectRid
 project_rid = "ri.compass.main.folder.01a79a9d-e293-48db-a585-9ffe221536e8"
@@ -255,10 +245,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.filesystem.Project.get(
-        project_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.filesystem.Project.get(project_rid, preview=preview)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -303,9 +290,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ProjectRid
 project_rid = "ri.compass.main.folder.01a79a9d-e293-48db-a585-9ffe221536e8"
@@ -318,11 +303,8 @@ preview = None
 
 
 try:
-    for project in foundry_client.filesystem.Project.organizations(
-        project_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for project in client.filesystem.Project.organizations(
+        project_rid, page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(project)
 except foundry.PalantirRPCException as e:
@@ -367,9 +349,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ProjectRid
 project_rid = "ri.compass.main.folder.01a79a9d-e293-48db-a585-9ffe221536e8"
@@ -383,10 +363,7 @@ preview = None
 
 try:
     api_response = foundry_client.filesystem.Project.organizations_page(
-        project_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        project_rid, page_size=page_size, page_token=page_token, preview=preview
     )
     print("The organizations_page response:\n")
     pprint(api_response)
@@ -429,9 +406,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ProjectRid
 project_rid = "ri.compass.main.folder.01a79a9d-e293-48db-a585-9ffe221536e8"
@@ -443,9 +418,7 @@ preview = None
 
 try:
     api_response = foundry_client.filesystem.Project.remove_organizations(
-        project_rid,
-        organization_rids=organization_rids,
-        preview=preview,
+        project_rid, organization_rids=organization_rids, preview=preview
     )
     print("The remove_organizations response:\n")
     pprint(api_response)

--- a/docs/v2/Filesystem/Resource.md
+++ b/docs/v2/Filesystem/Resource.md
@@ -34,9 +34,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ResourceRid
 resource_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -48,9 +46,7 @@ preview = None
 
 try:
     api_response = foundry_client.filesystem.Resource.add_markings(
-        resource_rid,
-        marking_ids=marking_ids,
-        preview=preview,
+        resource_rid, marking_ids=marking_ids, preview=preview
     )
     print("The add_markings response:\n")
     pprint(api_response)
@@ -94,9 +90,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ResourceRid
 resource_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -105,10 +99,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.filesystem.Resource.delete(
-        resource_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.filesystem.Resource.delete(resource_rid, preview=preview)
     print("The delete response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -149,9 +140,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ResourceRid
 resource_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -160,10 +149,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.filesystem.Resource.get(
-        resource_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.filesystem.Resource.get(resource_rid, preview=preview)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -206,9 +192,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ResourceRid
 resource_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -218,8 +202,7 @@ preview = None
 
 try:
     api_response = foundry_client.filesystem.Resource.get_access_requirements(
-        resource_rid,
-        preview=preview,
+        resource_rid, preview=preview
     )
     print("The get_access_requirements response:\n")
     pprint(api_response)
@@ -261,9 +244,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ResourcePath | The path to the Resource. The leading slash is optional.
 path = "/My Organization-abcd/My Important Project/My Dataset"
@@ -272,10 +253,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.filesystem.Resource.get_by_path(
-        path=path,
-        preview=preview,
-    )
+    api_response = foundry_client.filesystem.Resource.get_by_path(path=path, preview=preview)
     print("The get_by_path response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -320,9 +298,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ResourceRid
 resource_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -335,11 +311,8 @@ preview = None
 
 
 try:
-    for resource in foundry_client.filesystem.Resource.markings(
-        resource_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for resource in client.filesystem.Resource.markings(
+        resource_rid, page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(resource)
 except foundry.PalantirRPCException as e:
@@ -384,9 +357,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ResourceRid
 resource_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -400,10 +371,7 @@ preview = None
 
 try:
     api_response = foundry_client.filesystem.Resource.markings_page(
-        resource_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        resource_rid, page_size=page_size, page_token=page_token, preview=preview
     )
     print("The markings_page response:\n")
     pprint(api_response)
@@ -447,9 +415,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ResourceRid
 resource_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -459,8 +425,7 @@ preview = None
 
 try:
     api_response = foundry_client.filesystem.Resource.permanently_delete(
-        resource_rid,
-        preview=preview,
+        resource_rid, preview=preview
     )
     print("The permanently_delete response:\n")
     pprint(api_response)
@@ -503,9 +468,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ResourceRid
 resource_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -517,9 +480,7 @@ preview = None
 
 try:
     api_response = foundry_client.filesystem.Resource.remove_markings(
-        resource_rid,
-        marking_ids=marking_ids,
-        preview=preview,
+        resource_rid, marking_ids=marking_ids, preview=preview
     )
     print("The remove_markings response:\n")
     pprint(api_response)
@@ -563,9 +524,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ResourceRid
 resource_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -574,10 +533,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.filesystem.Resource.restore(
-        resource_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.filesystem.Resource.restore(resource_rid, preview=preview)
     print("The restore response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:

--- a/docs/v2/Filesystem/ResourceRole.md
+++ b/docs/v2/Filesystem/ResourceRole.md
@@ -28,9 +28,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ResourceRid
 resource_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -42,9 +40,7 @@ preview = None
 
 try:
     api_response = foundry_client.filesystem.Resource.Role.add(
-        resource_rid,
-        roles=roles,
-        preview=preview,
+        resource_rid, roles=roles, preview=preview
     )
     print("The add response:\n")
     pprint(api_response)
@@ -90,9 +86,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ResourceRid
 resource_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -107,7 +101,7 @@ preview = None
 
 
 try:
-    for resource_role in foundry_client.filesystem.Resource.Role.list(
+    for resource_role in client.filesystem.Resource.Role.list(
         resource_rid,
         include_inherited=include_inherited,
         page_size=page_size,
@@ -157,9 +151,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ResourceRid
 resource_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -222,9 +214,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ResourceRid
 resource_rid = "ri.foundry.main.dataset.c26f11c8-cdb3-4f44-9f5d-9816ea1c82da"
@@ -236,9 +226,7 @@ preview = None
 
 try:
     api_response = foundry_client.filesystem.Resource.Role.remove(
-        resource_rid,
-        roles=roles,
-        preview=preview,
+        resource_rid, roles=roles, preview=preview
     )
     print("The remove response:\n")
     pprint(api_response)

--- a/docs/v2/Filesystem/Space.md
+++ b/docs/v2/Filesystem/Space.md
@@ -28,9 +28,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Optional[PageSize] | The page size to use for the endpoint.
 page_size = None
@@ -41,10 +39,8 @@ preview = None
 
 
 try:
-    for space in foundry_client.filesystem.Space.list(
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for space in client.filesystem.Space.list(
+        page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(space)
 except foundry.PalantirRPCException as e:
@@ -88,9 +84,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Optional[PageSize] | The page size to use for the endpoint.
 page_size = None
@@ -102,9 +96,7 @@ preview = None
 
 try:
     api_response = foundry_client.filesystem.Space.page(
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        page_size=page_size, page_token=page_token, preview=preview
     )
     print("The page response:\n")
     pprint(api_response)

--- a/docs/v2/Functions/Query.md
+++ b/docs/v2/Functions/Query.md
@@ -30,9 +30,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # QueryApiName
 query_api_name = None
@@ -44,9 +42,7 @@ preview = None
 
 try:
     api_response = foundry_client.functions.Query.execute(
-        query_api_name,
-        parameters=parameters,
-        preview=preview,
+        query_api_name, parameters=parameters, preview=preview
     )
     print("The execute response:\n")
     pprint(api_response)
@@ -89,9 +85,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # QueryApiName
 query_api_name = None
@@ -100,10 +94,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.functions.Query.get(
-        query_api_name,
-        preview=preview,
-    )
+    api_response = foundry_client.functions.Query.get(query_api_name, preview=preview)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -145,9 +136,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # FunctionRid
 rid = None
@@ -156,10 +145,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.functions.Query.get_by_rid(
-        rid=rid,
-        preview=preview,
-    )
+    api_response = foundry_client.functions.Query.get_by_rid(rid=rid, preview=preview)
     print("The get_by_rid response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:

--- a/docs/v2/Functions/ValueType.md
+++ b/docs/v2/Functions/ValueType.md
@@ -25,9 +25,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ValueTypeRid
 value_type_rid = None
@@ -36,10 +34,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.functions.ValueType.get(
-        value_type_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.functions.ValueType.get(value_type_rid, preview=preview)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:

--- a/docs/v2/Functions/VersionId.md
+++ b/docs/v2/Functions/VersionId.md
@@ -26,9 +26,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ValueTypeRid
 value_type_rid = None
@@ -40,9 +38,7 @@ preview = None
 
 try:
     api_response = foundry_client.functions.ValueType.VersionId.get(
-        value_type_rid,
-        version_id_version_id,
-        preview=preview,
+        value_type_rid, version_id_version_id, preview=preview
     )
     print("The get response:\n")
     pprint(api_response)

--- a/docs/v2/MediaSets/MediaSet.md
+++ b/docs/v2/MediaSets/MediaSet.md
@@ -35,9 +35,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MediaSetRid
 media_set_rid = None
@@ -49,9 +47,7 @@ preview = None
 
 try:
     api_response = foundry_client.media_sets.MediaSet.abort(
-        media_set_rid,
-        transaction_id,
-        preview=preview,
+        media_set_rid, transaction_id, preview=preview
     )
     print("The abort response:\n")
     pprint(api_response)
@@ -97,9 +93,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MediaSetRid
 media_set_rid = None
@@ -111,9 +105,7 @@ preview = None
 
 try:
     api_response = foundry_client.media_sets.MediaSet.commit(
-        media_set_rid,
-        transaction_id,
-        preview=preview,
+        media_set_rid, transaction_id, preview=preview
     )
     print("The commit response:\n")
     pprint(api_response)
@@ -159,9 +151,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MediaSetRid
 media_set_rid = None
@@ -173,9 +163,7 @@ preview = None
 
 try:
     api_response = foundry_client.media_sets.MediaSet.create(
-        media_set_rid,
-        branch_name=branch_name,
-        preview=preview,
+        media_set_rid, branch_name=branch_name, preview=preview
     )
     print("The create response:\n")
     pprint(api_response)
@@ -222,9 +210,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MediaSetRid | The RID of the media set.
 media_set_rid = None
@@ -238,10 +224,7 @@ read_token = None
 
 try:
     api_response = foundry_client.media_sets.MediaSet.info(
-        media_set_rid,
-        media_item_rid,
-        preview=preview,
-        read_token=read_token,
+        media_set_rid, media_item_rid, preview=preview, read_token=read_token
     )
     print("The info response:\n")
     pprint(api_response)
@@ -288,9 +271,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MediaSetRid
 media_set_rid = None
@@ -304,10 +285,7 @@ read_token = None
 
 try:
     api_response = foundry_client.media_sets.MediaSet.read(
-        media_set_rid,
-        media_item_rid,
-        preview=preview,
-        read_token=read_token,
+        media_set_rid, media_item_rid, preview=preview, read_token=read_token
     )
     print("The read response:\n")
     pprint(api_response)
@@ -354,9 +332,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MediaSetRid
 media_set_rid = None
@@ -370,10 +346,7 @@ read_token = None
 
 try:
     api_response = foundry_client.media_sets.MediaSet.read_original(
-        media_set_rid,
-        media_item_rid,
-        preview=preview,
-        read_token=read_token,
+        media_set_rid, media_item_rid, preview=preview, read_token=read_token
     )
     print("The read_original response:\n")
     pprint(api_response)
@@ -420,9 +393,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MediaSetRid | The RID of the media set.
 media_set_rid = None
@@ -436,10 +407,7 @@ read_token = None
 
 try:
     api_response = foundry_client.media_sets.MediaSet.reference(
-        media_set_rid,
-        media_item_rid,
-        preview=preview,
-        read_token=read_token,
+        media_set_rid, media_item_rid, preview=preview, read_token=read_token
     )
     print("The reference response:\n")
     pprint(api_response)
@@ -492,9 +460,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # MediaSetRid
 media_set_rid = None

--- a/docs/v2/Ontologies/Action.md
+++ b/docs/v2/Ontologies/Action.md
@@ -38,9 +38,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -119,9 +117,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"

--- a/docs/v2/Ontologies/ActionType.md
+++ b/docs/v2/Ontologies/ActionType.md
@@ -30,9 +30,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -41,10 +39,7 @@ action_type = "promote-employee"
 
 
 try:
-    api_response = foundry_client.ontologies.Ontology.ActionType.get(
-        ontology,
-        action_type,
-    )
+    api_response = foundry_client.ontologies.Ontology.ActionType.get(ontology, action_type)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -88,9 +83,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -100,8 +93,7 @@ action_type_rid = "ri.ontology.main.action-type.7ed72754-7491-428a-bb18-4d7296eb
 
 try:
     api_response = foundry_client.ontologies.Ontology.ActionType.get_by_rid(
-        ontology,
-        action_type_rid,
+        ontology, action_type_rid
     )
     print("The get_by_rid response:\n")
     pprint(api_response)
@@ -150,9 +142,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -163,10 +153,8 @@ page_token = None
 
 
 try:
-    for action_type in foundry_client.ontologies.Ontology.ActionType.list(
-        ontology,
-        page_size=page_size,
-        page_token=page_token,
+    for action_type in client.ontologies.Ontology.ActionType.list(
+        ontology, page_size=page_size, page_token=page_token
     ):
         pprint(action_type)
 except foundry.PalantirRPCException as e:
@@ -214,9 +202,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -228,9 +214,7 @@ page_token = None
 
 try:
     api_response = foundry_client.ontologies.Ontology.ActionType.page(
-        ontology,
-        page_size=page_size,
-        page_token=page_token,
+        ontology, page_size=page_size, page_token=page_token
     )
     print("The page response:\n")
     pprint(api_response)

--- a/docs/v2/Ontologies/Attachment.md
+++ b/docs/v2/Ontologies/Attachment.md
@@ -29,18 +29,14 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AttachmentRid | The RID of the attachment.
 attachment_rid = "ri.attachments.main.attachment.bb32154e-e043-4b00-9461-93136ca96b6f"
 
 
 try:
-    api_response = foundry_client.ontologies.Attachment.get(
-        attachment_rid,
-    )
+    api_response = foundry_client.ontologies.Attachment.get(attachment_rid)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -84,18 +80,14 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # AttachmentRid | The RID of the attachment.
 attachment_rid = "ri.attachments.main.attachment.bb32154e-e043-4b00-9461-93136ca96b6f"
 
 
 try:
-    api_response = foundry_client.ontologies.Attachment.read(
-        attachment_rid,
-    )
+    api_response = foundry_client.ontologies.Attachment.read(attachment_rid)
     print("The read response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -146,9 +138,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # bytes | Body of the request
 body = None
@@ -162,10 +152,7 @@ filename = "My Image.jpeg"
 
 try:
     api_response = foundry_client.ontologies.Attachment.upload(
-        body,
-        content_length=content_length,
-        content_type=content_type,
-        filename=filename,
+        body, content_length=content_length, content_type=content_type, filename=filename
     )
     print("The upload response:\n")
     pprint(api_response)

--- a/docs/v2/Ontologies/AttachmentProperty.md
+++ b/docs/v2/Ontologies/AttachmentProperty.md
@@ -35,9 +35,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -111,9 +109,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -189,9 +185,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -267,9 +261,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"

--- a/docs/v2/Ontologies/LinkedObject.md
+++ b/docs/v2/Ontologies/LinkedObject.md
@@ -38,9 +38,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -138,9 +136,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -167,7 +163,7 @@ select = None
 
 
 try:
-    for linked_object in foundry_client.ontologies.LinkedObject.list_linked_objects(
+    for linked_object in client.ontologies.LinkedObject.list_linked_objects(
         ontology,
         object_type,
         primary_key,
@@ -243,9 +239,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"

--- a/docs/v2/Ontologies/MediaReferenceProperty.md
+++ b/docs/v2/Ontologies/MediaReferenceProperty.md
@@ -34,9 +34,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -112,9 +110,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -190,9 +186,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -210,12 +204,7 @@ preview = None
 
 try:
     api_response = foundry_client.ontologies.MediaReferenceProperty.upload(
-        ontology,
-        object_type,
-        property,
-        body,
-        media_item_path=media_item_path,
-        preview=preview,
+        ontology, object_type, property, body, media_item_path=media_item_path, preview=preview
     )
     print("The upload response:\n")
     pprint(api_response)

--- a/docs/v2/Ontologies/ObjectType.md
+++ b/docs/v2/Ontologies/ObjectType.md
@@ -33,9 +33,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -44,10 +42,7 @@ object_type = "employee"
 
 
 try:
-    api_response = foundry_client.ontologies.Ontology.ObjectType.get(
-        ontology,
-        object_type,
-    )
+    api_response = foundry_client.ontologies.Ontology.ObjectType.get(ontology, object_type)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -92,9 +87,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -106,9 +99,7 @@ preview = None
 
 try:
     api_response = foundry_client.ontologies.Ontology.ObjectType.get_full_metadata(
-        ontology,
-        object_type,
-        preview=preview,
+        ontology, object_type, preview=preview
     )
     print("The get_full_metadata response:\n")
     pprint(api_response)
@@ -155,9 +146,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -169,9 +158,7 @@ link_type = "directReport"
 
 try:
     api_response = foundry_client.ontologies.Ontology.ObjectType.get_outgoing_link_type(
-        ontology,
-        object_type,
-        link_type,
+        ontology, object_type, link_type
     )
     print("The get_outgoing_link_type response:\n")
     pprint(api_response)
@@ -221,9 +208,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -234,10 +219,8 @@ page_token = None
 
 
 try:
-    for object_type in foundry_client.ontologies.Ontology.ObjectType.list(
-        ontology,
-        page_size=page_size,
-        page_token=page_token,
+    for object_type in client.ontologies.Ontology.ObjectType.list(
+        ontology, page_size=page_size, page_token=page_token
     ):
         pprint(object_type)
 except foundry.PalantirRPCException as e:
@@ -284,9 +267,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -299,11 +280,8 @@ page_token = None
 
 
 try:
-    for object_type in foundry_client.ontologies.Ontology.ObjectType.list_outgoing_link_types(
-        ontology,
-        object_type,
-        page_size=page_size,
-        page_token=page_token,
+    for object_type in client.ontologies.Ontology.ObjectType.list_outgoing_link_types(
+        ontology, object_type, page_size=page_size, page_token=page_token
     ):
         pprint(object_type)
 except foundry.PalantirRPCException as e:
@@ -352,9 +330,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -366,9 +342,7 @@ page_token = None
 
 try:
     api_response = foundry_client.ontologies.Ontology.ObjectType.page(
-        ontology,
-        page_size=page_size,
-        page_token=page_token,
+        ontology, page_size=page_size, page_token=page_token
     )
     print("The page response:\n")
     pprint(api_response)
@@ -416,9 +390,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -432,10 +404,7 @@ page_token = None
 
 try:
     api_response = foundry_client.ontologies.Ontology.ObjectType.page_outgoing_link_types(
-        ontology,
-        object_type,
-        page_size=page_size,
-        page_token=page_token,
+        ontology, object_type, page_size=page_size, page_token=page_token
     )
     print("The page_outgoing_link_types response:\n")
     pprint(api_response)

--- a/docs/v2/Ontologies/Ontology.md
+++ b/docs/v2/Ontologies/Ontology.md
@@ -28,18 +28,14 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
 
 
 try:
-    api_response = foundry_client.ontologies.Ontology.get(
-        ontology,
-    )
+    api_response = foundry_client.ontologies.Ontology.get(ontology)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -80,18 +76,14 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
 
 
 try:
-    api_response = foundry_client.ontologies.Ontology.get_full_metadata(
-        ontology,
-    )
+    api_response = foundry_client.ontologies.Ontology.get_full_metadata(ontology)
     print("The get_full_metadata response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -133,9 +125,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 
 try:

--- a/docs/v2/Ontologies/OntologyInterface.md
+++ b/docs/v2/Ontologies/OntologyInterface.md
@@ -46,9 +46,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -135,9 +133,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -149,9 +145,7 @@ preview = None
 
 try:
     api_response = foundry_client.ontologies.OntologyInterface.get(
-        ontology,
-        interface_type,
-        preview=preview,
+        ontology, interface_type, preview=preview
     )
     print("The get response:\n")
     pprint(api_response)
@@ -206,9 +200,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -221,11 +213,8 @@ preview = None
 
 
 try:
-    for ontology_interface in foundry_client.ontologies.OntologyInterface.list(
-        ontology,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for ontology_interface in client.ontologies.OntologyInterface.list(
+        ontology, page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(ontology_interface)
 except foundry.PalantirRPCException as e:
@@ -279,9 +268,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -295,10 +282,7 @@ preview = None
 
 try:
     api_response = foundry_client.ontologies.OntologyInterface.page(
-        ontology,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        ontology, page_size=page_size, page_token=page_token, preview=preview
     )
     print("The page response:\n")
     pprint(api_response)
@@ -386,9 +370,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"

--- a/docs/v2/Ontologies/OntologyObject.md
+++ b/docs/v2/Ontologies/OntologyObject.md
@@ -38,9 +38,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -126,9 +124,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -142,10 +138,7 @@ package_name = None
 
 try:
     api_response = foundry_client.ontologies.OntologyObject.count(
-        ontology,
-        object_type,
-        artifact_repository=artifact_repository,
-        package_name=package_name,
+        ontology, object_type, artifact_repository=artifact_repository, package_name=package_name
     )
     print("The count response:\n")
     pprint(api_response)
@@ -195,9 +188,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -287,9 +278,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -312,7 +301,7 @@ select = None
 
 
 try:
-    for ontology_object in foundry_client.ontologies.OntologyObject.list(
+    for ontology_object in client.ontologies.OntologyObject.list(
         ontology,
         object_type,
         artifact_repository=artifact_repository,
@@ -384,9 +373,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -493,9 +480,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"

--- a/docs/v2/Ontologies/OntologyObjectSet.md
+++ b/docs/v2/Ontologies/OntologyObjectSet.md
@@ -37,9 +37,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -111,9 +109,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -123,8 +119,7 @@ object_set = {"type": "base", "objectType": "Employee"}
 
 try:
     api_response = foundry_client.ontologies.OntologyObjectSet.create_temporary(
-        ontology,
-        object_set=object_set,
+        ontology, object_set=object_set
     )
     print("The create_temporary response:\n")
     pprint(api_response)
@@ -169,9 +164,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -180,10 +173,7 @@ object_set_rid = "ri.object-set.main.object-set.c32ccba5-1a55-4cfe-ad71-160c4c77
 
 
 try:
-    api_response = foundry_client.ontologies.OntologyObjectSet.get(
-        ontology,
-        object_set_rid,
-    )
+    api_response = foundry_client.ontologies.OntologyObjectSet.get(ontology, object_set_rid)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -239,9 +229,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -336,9 +324,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -438,9 +424,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"

--- a/docs/v2/Ontologies/Query.md
+++ b/docs/v2/Ontologies/Query.md
@@ -33,9 +33,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"

--- a/docs/v2/Ontologies/QueryType.md
+++ b/docs/v2/Ontologies/QueryType.md
@@ -29,9 +29,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -40,10 +38,7 @@ query_api_name = "getEmployeesInCity"
 
 
 try:
-    api_response = foundry_client.ontologies.Ontology.QueryType.get(
-        ontology,
-        query_api_name,
-    )
+    api_response = foundry_client.ontologies.Ontology.QueryType.get(ontology, query_api_name)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -91,9 +86,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -104,10 +97,8 @@ page_token = None
 
 
 try:
-    for query_type in foundry_client.ontologies.Ontology.QueryType.list(
-        ontology,
-        page_size=page_size,
-        page_token=page_token,
+    for query_type in client.ontologies.Ontology.QueryType.list(
+        ontology, page_size=page_size, page_token=page_token
     ):
         pprint(query_type)
 except foundry.PalantirRPCException as e:
@@ -155,9 +146,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -169,9 +158,7 @@ page_token = None
 
 try:
     api_response = foundry_client.ontologies.Ontology.QueryType.page(
-        ontology,
-        page_size=page_size,
-        page_token=page_token,
+        ontology, page_size=page_size, page_token=page_token
     )
     print("The page response:\n")
     pprint(api_response)

--- a/docs/v2/Ontologies/TimeSeriesPropertyV2.md
+++ b/docs/v2/Ontologies/TimeSeriesPropertyV2.md
@@ -34,9 +34,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -109,9 +107,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -187,9 +183,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"

--- a/docs/v2/Ontologies/TimeSeriesValueBankProperty.md
+++ b/docs/v2/Ontologies/TimeSeriesValueBankProperty.md
@@ -33,9 +33,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"
@@ -109,9 +107,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # OntologyIdentifier | The API name of the ontology. To find the API name, use the **List ontologies** endpoint or check the **Ontology Manager**.
 ontology = "palantir"

--- a/docs/v2/Orchestration/Build.md
+++ b/docs/v2/Orchestration/Build.md
@@ -31,9 +31,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # BuildRid | The RID of a Build.
 build_rid = "ri.foundry.main.build.a4386b7e-d546-49be-8a36-eefc355f5c58"
@@ -42,10 +40,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.orchestration.Build.cancel(
-        build_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.orchestration.Build.cancel(build_rid, preview=preview)
     print("The cancel response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -93,14 +88,18 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # FallbackBranches
 fallback_branches = ["master"]
 # Union[BuildTarget, BuildTargetDict] | The targets of the schedule.
-target = None
+target = {
+    "type": "manual",
+    "targetRids": [
+        "ri.foundry.main.dataset.4263bdd9-d6bc-4244-9cca-893c1a2aef62",
+        "ri.foundry.main.dataset.86939c1e-4256-41db-9fe7-e7ee9e0f752a",
+    ],
+}
 # Optional[AbortOnFailure]
 abort_on_failure = False
 # Optional[BranchName] | The target branch the build should run on.
@@ -169,9 +168,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # BuildRid | The RID of a Build.
 build_rid = "ri.foundry.main.build.a4386b7e-d546-49be-8a36-eefc355f5c58"
@@ -180,10 +177,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.orchestration.Build.get(
-        build_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.orchestration.Build.get(build_rid, preview=preview)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -226,9 +220,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # List[Union[GetBuildsBatchRequestElement, GetBuildsBatchRequestElementDict]] | Body of the request
 body = [{"buildRid": "ri.foundry.main.build.a4386b7e-d546-49be-8a36-eefc355f5c58"}]
@@ -237,10 +229,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.orchestration.Build.get_batch(
-        body,
-        preview=preview,
-    )
+    api_response = foundry_client.orchestration.Build.get_batch(body, preview=preview)
     print("The get_batch response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -283,9 +272,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # BuildRid | The RID of a Build.
 build_rid = "ri.foundry.main.build.a4386b7e-d546-49be-8a36-eefc355f5c58"
@@ -298,11 +285,8 @@ preview = None
 
 
 try:
-    for build in foundry_client.orchestration.Build.jobs(
-        build_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for build in client.orchestration.Build.jobs(
+        build_rid, page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(build)
 except foundry.PalantirRPCException as e:
@@ -345,9 +329,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # BuildRid | The RID of a Build.
 build_rid = "ri.foundry.main.build.a4386b7e-d546-49be-8a36-eefc355f5c58"
@@ -361,10 +343,7 @@ preview = None
 
 try:
     api_response = foundry_client.orchestration.Build.jobs_page(
-        build_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        build_rid, page_size=page_size, page_token=page_token, preview=preview
     )
     print("The jobs_page response:\n")
     pprint(api_response)
@@ -409,9 +388,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Union[SearchBuildsFilter, SearchBuildsFilterDict]
 where = None
@@ -427,11 +404,7 @@ preview = None
 
 try:
     api_response = foundry_client.orchestration.Build.search(
-        where=where,
-        order_by=order_by,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        where=where, order_by=order_by, page_size=page_size, page_token=page_token, preview=preview
     )
     print("The search response:\n")
     pprint(api_response)

--- a/docs/v2/Orchestration/Job.md
+++ b/docs/v2/Orchestration/Job.md
@@ -25,9 +25,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # JobRid | The RID of a Job.
 job_rid = "ri.foundry.main.job.aaf94076-d773-4732-a1df-3b638eb50448"
@@ -36,10 +34,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.orchestration.Job.get(
-        job_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.orchestration.Job.get(job_rid, preview=preview)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -82,9 +77,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # List[Union[GetJobsBatchRequestElement, GetJobsBatchRequestElementDict]] | Body of the request
 body = [{"jobRid": "ri.foundry.main.job.aaf94076-d773-4732-a1df-3b638eb50448"}]
@@ -93,10 +86,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.orchestration.Job.get_batch(
-        body,
-        preview=preview,
-    )
+    api_response = foundry_client.orchestration.Job.get_batch(body, preview=preview)
     print("The get_batch response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:

--- a/docs/v2/Orchestration/Schedule.md
+++ b/docs/v2/Orchestration/Schedule.md
@@ -36,9 +36,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # Union[CreateScheduleRequestAction, CreateScheduleRequestActionDict]
 action = {
@@ -118,9 +116,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ScheduleRid
 schedule_rid = None
@@ -129,10 +125,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.orchestration.Schedule.delete(
-        schedule_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.orchestration.Schedule.delete(schedule_rid, preview=preview)
     print("The delete response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -173,9 +166,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ScheduleRid
 schedule_rid = None
@@ -184,10 +175,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.orchestration.Schedule.get(
-        schedule_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.orchestration.Schedule.get(schedule_rid, preview=preview)
     print("The get response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -228,9 +216,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ScheduleRid
 schedule_rid = None
@@ -239,10 +225,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.orchestration.Schedule.pause(
-        schedule_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.orchestration.Schedule.pause(schedule_rid, preview=preview)
     print("The pause response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -288,9 +271,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ScheduleRid
 schedule_rid = None
@@ -373,9 +354,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ScheduleRid
 schedule_rid = None
@@ -384,10 +363,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.orchestration.Schedule.run(
-        schedule_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.orchestration.Schedule.run(schedule_rid, preview=preview)
     print("The run response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -431,9 +407,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ScheduleRid
 schedule_rid = None
@@ -446,11 +420,8 @@ preview = None
 
 
 try:
-    for schedule in foundry_client.orchestration.Schedule.runs(
-        schedule_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+    for schedule in client.orchestration.Schedule.runs(
+        schedule_rid, page_size=page_size, page_token=page_token, preview=preview
     ):
         pprint(schedule)
 except foundry.PalantirRPCException as e:
@@ -494,9 +465,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ScheduleRid
 schedule_rid = None
@@ -510,10 +479,7 @@ preview = None
 
 try:
     api_response = foundry_client.orchestration.Schedule.runs_page(
-        schedule_rid,
-        page_size=page_size,
-        page_token=page_token,
-        preview=preview,
+        schedule_rid, page_size=page_size, page_token=page_token, preview=preview
     )
     print("The runs_page response:\n")
     pprint(api_response)
@@ -555,9 +521,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ScheduleRid
 schedule_rid = None
@@ -566,10 +530,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.orchestration.Schedule.unpause(
-        schedule_rid,
-        preview=preview,
-    )
+    api_response = foundry_client.orchestration.Schedule.unpause(schedule_rid, preview=preview)
     print("The unpause response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:

--- a/docs/v2/Orchestration/ScheduleVersion.md
+++ b/docs/v2/Orchestration/ScheduleVersion.md
@@ -25,9 +25,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ScheduleVersionRid | The RID of a schedule version
 schedule_version_rid = "ri.scheduler.main.schedule-version.4d1eb55f-6c13-411c-a911-5d84e08d8017"
@@ -37,8 +35,7 @@ preview = None
 
 try:
     api_response = foundry_client.orchestration.ScheduleVersion.get(
-        schedule_version_rid,
-        preview=preview,
+        schedule_version_rid, preview=preview
     )
     print("The get response:\n")
     pprint(api_response)
@@ -80,9 +77,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ScheduleVersionRid | The RID of a schedule version
 schedule_version_rid = "ri.scheduler.main.schedule-version.4d1eb55f-6c13-411c-a911-5d84e08d8017"
@@ -92,8 +87,7 @@ preview = None
 
 try:
     api_response = foundry_client.orchestration.ScheduleVersion.schedule(
-        schedule_version_rid,
-        preview=preview,
+        schedule_version_rid, preview=preview
     )
     print("The schedule response:\n")
     pprint(api_response)

--- a/docs/v2/SqlQueries/Query.md
+++ b/docs/v2/SqlQueries/Query.md
@@ -28,9 +28,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # QueryId | The id of a query.
 query_id = None
@@ -39,10 +37,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.sql_queries.Query.cancel(
-        query_id,
-        preview=preview,
-    )
+    api_response = foundry_client.sql_queries.Query.cancel(query_id, preview=preview)
     print("The cancel response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -85,9 +80,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # str | The SQL query to execute. Queries should confirm to the [Spark SQL dialect](https://spark.apache.org/docs/latest/sql-ref.html). This supports SELECT queries only.
 query = None
@@ -99,9 +92,7 @@ preview = None
 
 try:
     api_response = foundry_client.sql_queries.Query.execute(
-        query=query,
-        fallback_branch_ids=fallback_branch_ids,
-        preview=preview,
+        query=query, fallback_branch_ids=fallback_branch_ids, preview=preview
     )
     print("The execute response:\n")
     pprint(api_response)
@@ -145,9 +136,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # QueryId | The id of a query.
 query_id = None
@@ -156,10 +145,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.sql_queries.Query.get_results(
-        query_id,
-        preview=preview,
-    )
+    api_response = foundry_client.sql_queries.Query.get_results(query_id, preview=preview)
     print("The get_results response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:
@@ -201,9 +187,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # QueryId | The id of a query.
 query_id = None
@@ -212,10 +196,7 @@ preview = None
 
 
 try:
-    api_response = foundry_client.sql_queries.Query.get_status(
-        query_id,
-        preview=preview,
-    )
+    api_response = foundry_client.sql_queries.Query.get_status(query_id, preview=preview)
     print("The get_status response:\n")
     pprint(api_response)
 except foundry.PalantirRPCException as e:

--- a/docs/v2/Streams/Dataset.md
+++ b/docs/v2/Streams/Dataset.md
@@ -33,9 +33,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetName
 name = "My Dataset"

--- a/docs/v2/Streams/Stream.md
+++ b/docs/v2/Streams/Stream.md
@@ -35,9 +35,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -108,9 +106,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -122,9 +118,7 @@ preview = None
 
 try:
     api_response = foundry_client.streams.Dataset.Stream.get(
-        dataset_rid,
-        stream_branch_name,
-        preview=preview,
+        dataset_rid, stream_branch_name, preview=preview
     )
     print("The get response:\n")
     pprint(api_response)
@@ -170,9 +164,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -188,11 +180,7 @@ view_rid = None
 
 try:
     api_response = foundry_client.streams.Dataset.Stream.publish_binary_record(
-        dataset_rid,
-        stream_branch_name,
-        body,
-        preview=preview,
-        view_rid=view_rid,
+        dataset_rid, stream_branch_name, body, preview=preview, view_rid=view_rid
     )
     print("The publish_binary_record response:\n")
     pprint(api_response)
@@ -239,9 +227,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -257,11 +243,7 @@ view_rid = "ri.foundry-streaming.main.view.ecd4f0f6-8526-4468-9eda-14939449ad79"
 
 try:
     api_response = foundry_client.streams.Dataset.Stream.publish_record(
-        dataset_rid,
-        stream_branch_name,
-        record=record,
-        preview=preview,
-        view_rid=view_rid,
+        dataset_rid, stream_branch_name, record=record, preview=preview, view_rid=view_rid
     )
     print("The publish_record response:\n")
     pprint(api_response)
@@ -308,9 +290,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None
@@ -326,11 +306,7 @@ view_rid = "ri.foundry-streaming.main.view.ecd4f0f6-8526-4468-9eda-14939449ad79"
 
 try:
     api_response = foundry_client.streams.Dataset.Stream.publish_records(
-        dataset_rid,
-        stream_branch_name,
-        records=records,
-        preview=preview,
-        view_rid=view_rid,
+        dataset_rid, stream_branch_name, records=records, preview=preview, view_rid=view_rid
     )
     print("The publish_records response:\n")
     pprint(api_response)
@@ -384,9 +360,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # DatasetRid
 dataset_rid = None

--- a/docs/v2/ThirdPartyApplications/ThirdPartyApplication.md
+++ b/docs/v2/ThirdPartyApplications/ThirdPartyApplication.md
@@ -24,9 +24,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ThirdPartyApplicationRid | An RID identifying a third-party application created in Developer Console.
 third_party_application_rid = (
@@ -38,8 +36,7 @@ preview = None
 
 try:
     api_response = foundry_client.third_party_applications.ThirdPartyApplication.get(
-        third_party_application_rid,
-        preview=preview,
+        third_party_application_rid, preview=preview
     )
     print("The get response:\n")
     pprint(api_response)

--- a/docs/v2/ThirdPartyApplications/Version.md
+++ b/docs/v2/ThirdPartyApplications/Version.md
@@ -29,9 +29,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ThirdPartyApplicationRid | An RID identifying a third-party application created in Developer Console.
 third_party_application_rid = (
@@ -44,8 +42,7 @@ version_version = "1.2.0"
 try:
     api_response = (
         foundry_client.third_party_applications.ThirdPartyApplication.Website.Version.delete(
-            third_party_application_rid,
-            version_version,
+            third_party_application_rid, version_version
         )
     )
     print("The delete response:\n")
@@ -88,9 +85,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ThirdPartyApplicationRid | An RID identifying a third-party application created in Developer Console.
 third_party_application_rid = (
@@ -103,8 +98,7 @@ version_version = "1.2.0"
 try:
     api_response = (
         foundry_client.third_party_applications.ThirdPartyApplication.Website.Version.get(
-            third_party_application_rid,
-            version_version,
+            third_party_application_rid, version_version
         )
     )
     print("The get response:\n")
@@ -150,9 +144,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ThirdPartyApplicationRid | An RID identifying a third-party application created in Developer Console.
 third_party_application_rid = (
@@ -165,12 +157,8 @@ page_token = None
 
 
 try:
-    for (
-        version
-    ) in foundry_client.third_party_applications.ThirdPartyApplication.Website.Version.list(
-        third_party_application_rid,
-        page_size=page_size,
-        page_token=page_token,
+    for version in client.third_party_applications.ThirdPartyApplication.Website.Version.list(
+        third_party_application_rid, page_size=page_size, page_token=page_token
     ):
         pprint(version)
 except foundry.PalantirRPCException as e:
@@ -214,9 +202,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ThirdPartyApplicationRid | An RID identifying a third-party application created in Developer Console.
 third_party_application_rid = (
@@ -231,9 +217,7 @@ page_token = None
 try:
     api_response = (
         foundry_client.third_party_applications.ThirdPartyApplication.Website.Version.page(
-            third_party_application_rid,
-            page_size=page_size,
-            page_token=page_token,
+            third_party_application_rid, page_size=page_size, page_token=page_token
         )
     )
     print("The page response:\n")
@@ -277,9 +261,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ThirdPartyApplicationRid | An RID identifying a third-party application created in Developer Console.
 third_party_application_rid = (
@@ -294,9 +276,7 @@ version = None
 try:
     api_response = (
         foundry_client.third_party_applications.ThirdPartyApplication.Website.Version.upload(
-            third_party_application_rid,
-            body,
-            version=version,
+            third_party_application_rid, body, version=version
         )
     )
     print("The upload response:\n")
@@ -343,9 +323,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ThirdPartyApplicationRid | An RID identifying a third-party application created in Developer Console.
 third_party_application_rid = (

--- a/docs/v2/ThirdPartyApplications/Website.md
+++ b/docs/v2/ThirdPartyApplications/Website.md
@@ -26,9 +26,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ThirdPartyApplicationRid | An RID identifying a third-party application created in Developer Console.
 third_party_application_rid = (
@@ -40,8 +38,7 @@ version = "1.2.0"
 
 try:
     api_response = foundry_client.third_party_applications.ThirdPartyApplication.Website.deploy(
-        third_party_application_rid,
-        version=version,
+        third_party_application_rid, version=version
     )
     print("The deploy response:\n")
     pprint(api_response)
@@ -82,9 +79,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ThirdPartyApplicationRid | An RID identifying a third-party application created in Developer Console.
 third_party_application_rid = (
@@ -94,7 +89,7 @@ third_party_application_rid = (
 
 try:
     api_response = foundry_client.third_party_applications.ThirdPartyApplication.Website.get(
-        third_party_application_rid,
+        third_party_application_rid
     )
     print("The get response:\n")
     pprint(api_response)
@@ -135,9 +130,7 @@ from foundry.v2 import FoundryClient
 import foundry
 from pprint import pprint
 
-foundry_client = FoundryClient(
-    auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com"
-)
+client = FoundryClient(auth=foundry.UserTokenAuth(...), hostname="example.palantirfoundry.com")
 
 # ThirdPartyApplicationRid | An RID identifying a third-party application created in Developer Console.
 third_party_application_rid = (
@@ -147,7 +140,7 @@ third_party_application_rid = (
 
 try:
     api_response = foundry_client.third_party_applications.ThirdPartyApplication.Website.undeploy(
-        third_party_application_rid,
+        third_party_application_rid
     )
     print("The undeploy response:\n")
     pprint(api_response)

--- a/foundry/_versions.py
+++ b/foundry/_versions.py
@@ -17,4 +17,4 @@
 # using the autorelease bot
 __version__ = "0.0.0"
 
-__openapi_document_version__ = "1.1122.0"
+__openapi_document_version__ = "1.1126.0"

--- a/foundry/v2/datasets/branch.py
+++ b/foundry/v2/datasets/branch.py
@@ -189,7 +189,6 @@ class BranchClient:
         :rtype: datasets_models.Branch
 
         :raises BranchNotFound: The requested branch could not be found, or the client token does not have access to it.
-        :raises BranchNotFound: The requested branch could not be found, or the client token does not have access to it.
         :raises DatasetNotFound: The requested dataset could not be found, or the client token does not have access to it.
         """
 
@@ -210,7 +209,6 @@ class BranchClient:
                 response_type=datasets_models.Branch,
                 request_timeout=request_timeout,
                 throwable_errors={
-                    "BranchNotFound": datasets_errors.BranchNotFound,
                     "BranchNotFound": datasets_errors.BranchNotFound,
                     "DatasetNotFound": datasets_errors.DatasetNotFound,
                 },

--- a/foundry/v2/datasets/dataset.py
+++ b/foundry/v2/datasets/dataset.py
@@ -156,7 +156,6 @@ class DatasetClient:
         :rtype: datasets_models.Dataset
 
         :raises DatasetNotFound: The requested dataset could not be found, or the client token does not have access to it.
-        :raises DatasetNotFound: The requested dataset could not be found, or the client token does not have access to it.
         :raises ResourceNameAlreadyExists: The provided resource name is already in use by another resource in the same folder.
         """
 
@@ -176,7 +175,6 @@ class DatasetClient:
                 response_type=datasets_models.Dataset,
                 request_timeout=request_timeout,
                 throwable_errors={
-                    "DatasetNotFound": datasets_errors.DatasetNotFound,
                     "DatasetNotFound": datasets_errors.DatasetNotFound,
                     "ResourceNameAlreadyExists": filesystem_errors.ResourceNameAlreadyExists,
                 },
@@ -226,7 +224,6 @@ class DatasetClient:
 
         :raises ColumnTypesNotSupported: The dataset contains column types that are not supported.
         :raises ReadTableDatasetPermissionDenied: The provided token does not have permission to read the given dataset as a table.
-        :raises ReadTableDatasetPermissionDenied: The provided token does not have permission to read the given dataset as a table.
         :raises ReadTableError: An error occurred while reading the table. Refer to the message for more details.
         :raises ReadTableRowLimitExceeded: The request to read the table generates a result that exceeds the allowed number of rows. For datasets not stored as Parquet there is a limit of 1 million rows. For datasets stored as Parquet there is no limit.
         :raises ReadTableTimeout: The request to read the table timed out.
@@ -257,7 +254,6 @@ class DatasetClient:
                 request_timeout=request_timeout,
                 throwable_errors={
                     "ColumnTypesNotSupported": datasets_errors.ColumnTypesNotSupported,
-                    "ReadTableDatasetPermissionDenied": datasets_errors.ReadTableDatasetPermissionDenied,
                     "ReadTableDatasetPermissionDenied": datasets_errors.ReadTableDatasetPermissionDenied,
                     "ReadTableError": datasets_errors.ReadTableError,
                     "ReadTableRowLimitExceeded": datasets_errors.ReadTableRowLimitExceeded,


### PR DESCRIPTION
To support a second SDK target, the examples in the README had to be generalized using the config file.