### PR TITLE
Fix FoundryClient hostname not propagated to OAuth auth objects

### DIFF
--- a/foundry_sdk/_core/oauth_utils.py
+++ b/foundry_sdk/_core/oauth_utils.py
@@ -119,7 +119,10 @@ class OAuth(Auth, ABC):
         config: Optional[Config] = None,
     ) -> None:
         self._config = config
-        self._hostname_supplier = maybe_create_hostname_supplier(hostname, config)
+        if hostname is not None:
+            self._hostname_supplier = maybe_create_hostname_supplier(hostname, config)
+        else:
+            self._hostname_supplier = None
         self._client: Optional[HttpClient] = None
         self._should_refresh = should_refresh
         self._stop_refresh_event = threading.Event()
@@ -233,6 +236,8 @@ class OAuth(Auth, ABC):
 
     def _get_base_url(self) -> str:
         if self._hostname_supplier is None:
+            self._hostname_supplier = maybe_create_hostname_supplier(None, self._config)
+        if self._hostname_supplier is None:
             raise ValueError(
                 f"The hostname must be provided to {self.__class__.__name__} when fetching a token."
             )
@@ -240,6 +245,8 @@ class OAuth(Auth, ABC):
 
     def _get_client(self) -> HttpClient:
         if self._client is None:
+            if self._hostname_supplier is None:
+                self._hostname_supplier = maybe_create_hostname_supplier(None, self._config)
             if self._hostname_supplier is None:
                 raise ValueError(
                     f"The hostname must be provided to {self.__class__.__name__} when fetching a token."

--- a/tests/test_oauth_hostname_parameterize.py
+++ b/tests/test_oauth_hostname_parameterize.py
@@ -1,0 +1,106 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests that FoundryClient hostname is correctly propagated to OAuth auth objects
+even when environment variables would otherwise provide a hostname."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from foundry_sdk._core.confidential_client_auth import ConfidentialClientAuth
+from foundry_sdk._core.hostname_supplier import EndpointType
+from foundry_sdk._core.hostname_supplier import StaticHostnameSupplier
+
+
+class TestOAuthHostnameParameterize:
+    """Regression tests for hostname propagation from FoundryClient to OAuth auth objects."""
+
+    def test_parameterize_sets_hostname_when_no_hostname_provided(self):
+        """When auth is created without a hostname, _parameterize should set it."""
+        auth = ConfidentialClientAuth(
+            client_id="my-client-id",
+            client_secret="my-client-secret",
+        )
+        assert auth._hostname_supplier is None
+
+        supplier = StaticHostnameSupplier("https://correct.host.com")
+        auth._parameterize(supplier, None)
+
+        assert auth._hostname_supplier is supplier
+        assert auth._get_base_url() == "https://correct.host.com/multipass/api"
+
+    def test_parameterize_preserves_explicit_hostname(self):
+        """When auth is created with an explicit hostname, _parameterize should not override it."""
+        auth = ConfidentialClientAuth(
+            client_id="my-client-id",
+            client_secret="my-client-secret",
+            hostname="https://explicit.host.com",
+        )
+        assert auth._hostname_supplier is not None
+
+        supplier = StaticHostnameSupplier("https://other.host.com")
+        auth._parameterize(supplier, None)
+
+        # The explicit hostname should be preserved (not overridden)
+        assert auth._get_base_url() == "https://explicit.host.com/multipass/api"
+
+    def test_parameterize_overrides_env_hostname(self):
+        """Regression test: when FOUNDRY_HOSTNAME env var is set but auth has no explicit hostname,
+        _parameterize from FoundryClient should take precedence over the env var.
+
+        Previously, OAuth.__init__ eagerly resolved the env var into _hostname_supplier,
+        which caused _parameterize to skip setting the FoundryClient's hostname.
+        """
+        with patch.dict(os.environ, {"FOUNDRY_HOSTNAME": "https://env.host.com"}):
+            auth = ConfidentialClientAuth(
+                client_id="my-client-id",
+                client_secret="my-client-secret",
+            )
+            # hostname_supplier should be None because no explicit hostname was given
+            assert auth._hostname_supplier is None
+
+            # Simulate what FoundryClient does: call _parameterize with its own hostname
+            foundry_client_supplier = StaticHostnameSupplier("https://foundryclient.host.com")
+            auth._parameterize(foundry_client_supplier, None)
+
+            # The FoundryClient hostname should win, NOT the env var
+            assert auth._hostname_supplier is foundry_client_supplier
+            assert auth._get_base_url() == "https://foundryclient.host.com/multipass/api"
+
+    def test_standalone_auth_falls_back_to_env_var(self):
+        """When auth is used standalone (no FoundryClient, no _parameterize call),
+        it should lazily resolve the hostname from environment variables."""
+        with patch.dict(os.environ, {"FOUNDRY_HOSTNAME": "https://env.host.com"}):
+            auth = ConfidentialClientAuth(
+                client_id="my-client-id",
+                client_secret="my-client-secret",
+            )
+            assert auth._hostname_supplier is None
+
+            # Calling _get_base_url without _parameterize should lazily resolve from env
+            base_url = auth._get_base_url()
+            assert base_url == "https://env.host.com/multipass/api"
+
+    def test_standalone_auth_raises_without_hostname_or_env(self):
+        """When auth is used standalone with no hostname and no env vars,
+        _get_base_url should raise ValueError."""
+        with patch.dict(os.environ, {}, clear=True):
+            auth = ConfidentialClientAuth(
+                client_id="my-client-id",
+                client_secret="my-client-secret",
+            )
+            with pytest.raises(ValueError, match="hostname must be provided"):
+                auth._get_base_url()


### PR DESCRIPTION
## Summary

- Fix bug where `FoundryClient(hostname=..., auth=auth)` hostname was not propagated to `ConfidentialClientAuth` (or other OAuth auth objects) when environment variables (`FOUNDRY_HOSTNAME`) or service discovery (`FOUNDRY_SERVICE_DISCOVERY_V2`) were present
- `OAuth.__init__` no longer eagerly resolves hostname from environment; instead, environment/service-discovery resolution is deferred to lazy fallback in `_get_base_url` and `_get_client`
- Add regression tests covering hostname propagation via `_parameterize`, standalone env-var fallback, and explicit hostname preservation

## Problem

When a user creates `ConfidentialClientAuth` without a hostname and passes it to `FoundryClient(hostname="correct.host.com", auth=auth)`, the auth should pick up the hostname from the `FoundryClient` via `_parameterize`. However, if `FOUNDRY_HOSTNAME` or `FOUNDRY_SERVICE_DISCOVERY_V2` is set in the environment (common inside Foundry), `OAuth.__init__` eagerly resolved a hostname supplier from those sources. This caused `_parameterize` to see `self._hostname_supplier is not None` and skip setting the FoundryClient's hostname, resulting in auth requests going to the wrong host (e.g., `localhost:8188` instead of `correct.host.com`).

## Fix

**`foundry_sdk/_core/oauth_utils.py`**

1. **`OAuth.__init__`**: Only create a hostname supplier when `hostname` is explicitly provided. When `hostname is None`, set `self._hostname_supplier = None` so `_parameterize` can set it later.
2. **`_get_base_url` / `_get_client`**: Before raising `ValueError` for a missing supplier, attempt lazy resolution via `maybe_create_hostname_supplier(None, self._config)`. This preserves standalone usage where env vars or service discovery should still work.

## Tests

- [x] `test_parameterize_sets_hostname_when_no_hostname_provided` — basic `_parameterize` propagation works
- [x] `test_parameterize_preserves_explicit_hostname` — explicit hostname on auth is not overridden
- [x] `test_parameterize_overrides_env_hostname` — **regression**: env var doesn't block `_parameterize` from setting FoundryClient hostname
- [x] `test_standalone_auth_falls_back_to_env_var` — standalone auth still lazily resolves from env
- [x] `test_standalone_auth_raises_without_hostname_or_env` — proper error when no hostname available