### PR TITLE
Implement get_async_http_client function for async Foundry HTTP clients

### DIFF
--- a/assets/language_model_utils.py
+++ b/assets/language_model_utils.py
@@ -19,7 +19,7 @@ from typing import Optional
 from foundry_sdk._core.config import Config
 from foundry_sdk._core.context_and_environment_vars import HOSTNAME_VAR
 from foundry_sdk._core.context_and_environment_vars import TOKEN_VAR
-from foundry_sdk._core.http_client import HttpClient
+from foundry_sdk._core.http_client import HttpClient, AsyncHttpClient
 
 
 def _get_api_gateway_base_url(*, preview: bool = False) -> str:
@@ -125,20 +125,58 @@ def get_http_client(*, preview: bool = False, config: Optional[Config] = None) -
 
     Raises:
         ValueError: If preview is not set to True.
-        RuntimeError: If the Foundry API gateway base URL or token is not available in the current context.
+        RuntimeError: If the Foundry token is not available in the current context.
     """
     if not preview:
         raise ValueError(
             "get_http_client() is in beta. " "Please set the preview parameter to True to use it."
         )
-    token = get_foundry_token(preview=True)
 
-    # Merge auth header with any user-provided headers
+    return HttpClient(config=_create_http_client_config(config))
+
+
+def get_async_http_client(
+    *, preview: bool = False, config: Optional[Config] = None
+) -> AsyncHttpClient:
+    """Get an async HTTP client configured for the current Foundry environment.
+
+    Args:
+        preview: Must be set to True to use this beta feature.
+        config: Optional configuration for the async HTTP client.
+
+    Returns:
+        An AsyncHttpClient instance configured with the Foundry hostname and authentication.
+
+    Raises:
+        ValueError: If preview is not set to True.
+        RuntimeError: If the Foundry token is not available in the current context.
+    """
+    if not preview:
+        raise ValueError(
+            "get_async_http_client() is in beta. "
+            "Please set the preview parameter to True to use it."
+        )
+
+    return AsyncHttpClient(config=_create_http_client_config(config))
+
+
+def _create_http_client_config(config: Optional[Config]) -> Config:
+    """Create a Config object for the HTTP client, ensuring that the Foundry token is included in the headers.
+
+    Args:
+        config: An optional Config object provided by the user.
+
+    Returns:
+        A Config object with the Foundry token included in the default headers.
+
+    Raises:
+        RuntimeError: If the Foundry token is not available in the current context.
+    """
+    token = get_foundry_token(preview=True)
     auth_header = {"Authorization": f"Bearer {token}"}
+
     if config is None:
-        config = Config(default_headers=auth_header)
+        return Config(default_headers=auth_header)
     else:
         merged_headers = {**auth_header, **(config.default_headers or {})}
-        config = replace(config, default_headers=merged_headers)
-
-    return HttpClient(config=config)
+        return replace(config, default_headers=merged_headers)

--- a/assets/test_language_model_utils.py
+++ b/assets/test_language_model_utils.py
@@ -17,11 +17,12 @@ import pytest
 
 from foundry_sdk._core.context_and_environment_vars import HOSTNAME_VAR
 from foundry_sdk._core.context_and_environment_vars import TOKEN_VAR
-from foundry_sdk._core.http_client import HttpClient
+from foundry_sdk._core.http_client import HttpClient, AsyncHttpClient
 from foundry_sdk.v2.language_models import (
     get_anthropic_base_url,
     get_foundry_token,
     get_http_client,
+    get_async_http_client,
     get_openai_base_url,
 )
 from foundry_sdk.v2.language_models.utils import _get_api_gateway_base_url
@@ -177,3 +178,17 @@ class TestGetHttpClient:
                 get_http_client(preview=True)
         finally:
             HOSTNAME_VAR.reset(hostname_token)
+
+
+class TestGetAsyncHttpClient:
+    """Test get_async_http_client function."""
+
+    def test_returns_http_client(self):
+        hostname_token = HOSTNAME_VAR.set("test.palantirfoundry.com")
+        auth_token = TOKEN_VAR.set("test-token-12345")
+        try:
+            result = get_async_http_client(preview=True)
+            assert isinstance(result, AsyncHttpClient)
+        finally:
+            HOSTNAME_VAR.reset(hostname_token)
+            TOKEN_VAR.reset(auth_token)

--- a/assets/test_language_model_utils.py
+++ b/assets/test_language_model_utils.py
@@ -183,7 +183,7 @@ class TestGetHttpClient:
 class TestGetAsyncHttpClient:
     """Test get_async_http_client function."""
 
-    def test_returns_http_client(self):
+    def test_returns_async_http_client(self):
         hostname_token = HOSTNAME_VAR.set("test.palantirfoundry.com")
         auth_token = TOKEN_VAR.set("test-token-12345")
         try:

--- a/config.json
+++ b/config.json
@@ -186,7 +186,8 @@
             "from foundry_sdk.v2.language_models.utils import get_foundry_token",
             "from foundry_sdk.v2.language_models.utils import get_openai_base_url",
             "from foundry_sdk.v2.language_models.utils import get_anthropic_base_url",
-            "from foundry_sdk.v2.language_models.utils import get_http_client"
+            "from foundry_sdk.v2.language_models.utils import get_http_client",
+            "from foundry_sdk.v2.language_models.utils import get_async_http_client"
           ]
         },
         "MapRendering": false,

--- a/foundry_sdk/v2/language_models/utils.py
+++ b/foundry_sdk/v2/language_models/utils.py
@@ -144,7 +144,9 @@ def get_http_client(*, preview: bool = False, config: Optional[Config] = None) -
     return HttpClient(config=config)
 
 
-def get_async_http_client(*, preview: bool = False, config: Optional[Config] = None) -> AsyncHttpClient:
+def get_async_http_client(
+    *, preview: bool = False, config: Optional[Config] = None
+) -> AsyncHttpClient:
     """Get an async HTTP client configured for the current Foundry environment.
 
     Args:
@@ -160,7 +162,8 @@ def get_async_http_client(*, preview: bool = False, config: Optional[Config] = N
     """
     if not preview:
         raise ValueError(
-            "get_async_http_client() is in beta. " "Please set the preview parameter to True to use it."
+            "get_async_http_client() is in beta. "
+            "Please set the preview parameter to True to use it."
         )
     token = get_foundry_token(preview=True)
 

--- a/foundry_sdk/v2/language_models/utils.py
+++ b/foundry_sdk/v2/language_models/utils.py
@@ -19,7 +19,7 @@ from typing import Optional
 from foundry_sdk._core.config import Config
 from foundry_sdk._core.context_and_environment_vars import HOSTNAME_VAR
 from foundry_sdk._core.context_and_environment_vars import TOKEN_VAR
-from foundry_sdk._core.http_client import HttpClient, AsyncHttpClient
+from foundry_sdk._core.http_client import HttpClient
 
 
 def _get_api_gateway_base_url(*, preview: bool = False) -> str:
@@ -125,58 +125,20 @@ def get_http_client(*, preview: bool = False, config: Optional[Config] = None) -
 
     Raises:
         ValueError: If preview is not set to True.
-        RuntimeError: If the Foundry token is not available in the current context.
+        RuntimeError: If the Foundry API gateway base URL or token is not available in the current context.
     """
     if not preview:
         raise ValueError(
             "get_http_client() is in beta. " "Please set the preview parameter to True to use it."
         )
-
-    return HttpClient(config=_create_http_client_config(config))
-
-
-def get_async_http_client(
-    *, preview: bool = False, config: Optional[Config] = None
-) -> AsyncHttpClient:
-    """Get an async HTTP client configured for the current Foundry environment.
-
-    Args:
-        preview: Must be set to True to use this beta feature.
-        config: Optional configuration for the async HTTP client.
-
-    Returns:
-        An AsyncHttpClient instance configured with the Foundry hostname and authentication.
-
-    Raises:
-        ValueError: If preview is not set to True.
-        RuntimeError: If the Foundry token is not available in the current context.
-    """
-    if not preview:
-        raise ValueError(
-            "get_async_http_client() is in beta. "
-            "Please set the preview parameter to True to use it."
-        )
-
-    return AsyncHttpClient(config=_create_http_client_config(config))
-
-
-def _create_http_client_config(config: Optional[Config]) -> Config:
-    """Create a Config object for the HTTP client, ensuring that the Foundry token is included in the headers.
-
-    Args:
-        config: An optional Config object provided by the user.
-
-    Returns:
-        A Config object with the Foundry token included in the default headers.
-
-    Raises:
-        RuntimeError: If the Foundry token is not available in the current context.
-    """
     token = get_foundry_token(preview=True)
-    auth_header = {"Authorization": f"Bearer {token}"}
 
+    # Merge auth header with any user-provided headers
+    auth_header = {"Authorization": f"Bearer {token}"}
     if config is None:
-        return Config(default_headers=auth_header)
+        config = Config(default_headers=auth_header)
     else:
         merged_headers = {**auth_header, **(config.default_headers or {})}
-        return replace(config, default_headers=merged_headers)
+        config = replace(config, default_headers=merged_headers)
+
+    return HttpClient(config=config)

--- a/foundry_sdk/v2/language_models/utils.py
+++ b/foundry_sdk/v2/language_models/utils.py
@@ -125,7 +125,7 @@ def get_http_client(*, preview: bool = False, config: Optional[Config] = None) -
 
     Raises:
         ValueError: If preview is not set to True.
-        RuntimeError: If the Foundry API gateway base URL or token is not available in the current context.
+        RuntimeError: If the Foundry token is not available in the current context.
     """
     if not preview:
         raise ValueError(
@@ -149,7 +149,7 @@ def get_async_http_client(
 
     Raises:
         ValueError: If preview is not set to True.
-        RuntimeError: If the Foundry API gateway base URL or token is not available in the current context.
+        RuntimeError: If the Foundry token is not available in the current context.
     """
     if not preview:
         raise ValueError(
@@ -168,6 +168,9 @@ def _create_http_client_config(config: Optional[Config]) -> Config:
 
     Returns:
         A Config object with the Foundry token included in the default headers.
+
+    Raises:
+        RuntimeError: If the Foundry token is not available in the current context.
     """
     token = get_foundry_token(preview=True)
     auth_header = {"Authorization": f"Bearer {token}"}

--- a/foundry_sdk/v2/language_models/utils.py
+++ b/foundry_sdk/v2/language_models/utils.py
@@ -131,17 +131,8 @@ def get_http_client(*, preview: bool = False, config: Optional[Config] = None) -
         raise ValueError(
             "get_http_client() is in beta. " "Please set the preview parameter to True to use it."
         )
-    token = get_foundry_token(preview=True)
 
-    # Merge auth header with any user-provided headers
-    auth_header = {"Authorization": f"Bearer {token}"}
-    if config is None:
-        config = Config(default_headers=auth_header)
-    else:
-        merged_headers = {**auth_header, **(config.default_headers or {})}
-        config = replace(config, default_headers=merged_headers)
-
-    return HttpClient(config=config)
+    return HttpClient(config=_create_http_client_config(config))
 
 
 def get_async_http_client(
@@ -165,14 +156,24 @@ def get_async_http_client(
             "get_async_http_client() is in beta. "
             "Please set the preview parameter to True to use it."
         )
-    token = get_foundry_token(preview=True)
 
-    # Merge auth header with any user-provided headers
+    return AsyncHttpClient(config=_create_http_client_config(config))
+
+
+def _create_http_client_config(config: Optional[Config]) -> Config:
+    """Create a Config object for the HTTP client, ensuring that the Foundry token is included in the headers.
+
+    Args:
+        config: An optional Config object provided by the user.
+
+    Returns:
+        A Config object with the Foundry token included in the default headers.
+    """
+    token = get_foundry_token(preview=True)
     auth_header = {"Authorization": f"Bearer {token}"}
+
     if config is None:
-        config = Config(default_headers=auth_header)
+        return Config(default_headers=auth_header)
     else:
         merged_headers = {**auth_header, **(config.default_headers or {})}
-        config = replace(config, default_headers=merged_headers)
-
-    return AsyncHttpClient(config=config)
+        return replace(config, default_headers=merged_headers)

--- a/foundry_sdk/v2/language_models/utils.py
+++ b/foundry_sdk/v2/language_models/utils.py
@@ -19,7 +19,7 @@ from typing import Optional
 from foundry_sdk._core.config import Config
 from foundry_sdk._core.context_and_environment_vars import HOSTNAME_VAR
 from foundry_sdk._core.context_and_environment_vars import TOKEN_VAR
-from foundry_sdk._core.http_client import HttpClient
+from foundry_sdk._core.http_client import HttpClient, AsyncHttpClient
 
 
 def _get_api_gateway_base_url(*, preview: bool = False) -> str:
@@ -142,3 +142,34 @@ def get_http_client(*, preview: bool = False, config: Optional[Config] = None) -
         config = replace(config, default_headers=merged_headers)
 
     return HttpClient(config=config)
+
+
+def get_async_http_client(*, preview: bool = False, config: Optional[Config] = None) -> AsyncHttpClient:
+    """Get an async HTTP client configured for the current Foundry environment.
+
+    Args:
+        preview: Must be set to True to use this beta feature.
+        config: Optional configuration for the async HTTP client.
+
+    Returns:
+        An AsyncHttpClient instance configured with the Foundry hostname and authentication.
+
+    Raises:
+        ValueError: If preview is not set to True.
+        RuntimeError: If the Foundry API gateway base URL or token is not available in the current context.
+    """
+    if not preview:
+        raise ValueError(
+            "get_async_http_client() is in beta. " "Please set the preview parameter to True to use it."
+        )
+    token = get_foundry_token(preview=True)
+
+    # Merge auth header with any user-provided headers
+    auth_header = {"Authorization": f"Bearer {token}"}
+    if config is None:
+        config = Config(default_headers=auth_header)
+    else:
+        merged_headers = {**auth_header, **(config.default_headers or {})}
+        config = replace(config, default_headers=merged_headers)
+
+    return AsyncHttpClient(config=config)


### PR DESCRIPTION
We would like to have a async HTTP client available so we can use async programming patterns when making API calls to Foundry.