### PR TITLE
define llm util for the google base url 

### DIFF
--- a/assets/language_model_utils.py
+++ b/assets/language_model_utils.py
@@ -113,6 +113,28 @@ def get_anthropic_base_url(*, preview: bool = False) -> str:
     return f"https://{hostname}/api/v2/llm/proxy/anthropic"
 
 
+def get_google_base_url(*, preview: bool = False) -> str:
+    """Get the Google proxy base URL for the current Foundry environment.
+
+    Args:
+        preview: Must be set to True to use this beta feature.
+
+    Returns:
+        The Google proxy base URL.
+
+    Raises:
+        ValueError: If preview is not set to True.
+        RuntimeError: If the Foundry API gateway base URL is not available in the current context.
+    """
+    if not preview:
+        raise ValueError(
+            "get_google_base_url() is in beta. "
+            "Please set the preview parameter to True to use it."
+        )
+    hostname = _get_api_gateway_base_url(preview=True)
+    return f"https://{hostname}/api/v2/llm/proxy/google"
+
+
 def get_http_client(*, preview: bool = False, config: Optional[Config] = None) -> HttpClient:
     """Get an HTTP client configured for the current Foundry environment.
 

--- a/assets/language_model_utils.py
+++ b/assets/language_model_utils.py
@@ -114,13 +114,13 @@ def get_anthropic_base_url(*, preview: bool = False) -> str:
 
 
 def get_google_base_url(*, preview: bool = False) -> str:
-    """Get the Google proxy base URL for the current Foundry environment.
+    """Get the Google proxy base URL for use with the google-genai SDK.
 
     Args:
         preview: Must be set to True to use this beta feature.
 
     Returns:
-        The Google proxy base URL.
+        The Google proxy base URL for the current Foundry environment.
 
     Raises:
         ValueError: If preview is not set to True.

--- a/assets/test_language_model_utils.py
+++ b/assets/test_language_model_utils.py
@@ -21,6 +21,7 @@ from foundry_sdk._core.http_client import HttpClient, AsyncHttpClient
 from foundry_sdk.v2.language_models import (
     get_anthropic_base_url,
     get_foundry_token,
+    get_google_base_url,
     get_http_client,
     get_async_http_client,
     get_openai_base_url,
@@ -46,6 +47,10 @@ class TestPreviewParameter:
     def test_get_anthropic_base_url_requires_preview(self):
         with pytest.raises(ValueError, match="preview parameter"):
             get_anthropic_base_url()
+
+    def test_get_google_base_url_requires_preview(self):
+        with pytest.raises(ValueError, match="preview parameter"):
+            get_google_base_url()
 
     def test_get_http_client_requires_preview(self):
         with pytest.raises(ValueError, match="preview parameter"):
@@ -114,6 +119,22 @@ class TestGetAnthropicBaseUrl:
     def test_raises_runtime_error_when_not_in_context(self):
         with pytest.raises(RuntimeError, match="not available"):
             get_anthropic_base_url(preview=True)
+
+
+class TestGetGoogleBaseUrl:
+    """Test get_google_base_url function."""
+
+    def test_returns_correct_url(self):
+        token = HOSTNAME_VAR.set("test.palantirfoundry.com")
+        try:
+            result = get_google_base_url(preview=True)
+            assert result == "https://test.palantirfoundry.com/api/v2/llm/proxy/google"
+        finally:
+            HOSTNAME_VAR.reset(token)
+
+    def test_raises_runtime_error_when_not_in_context(self):
+        with pytest.raises(RuntimeError, match="not available"):
+            get_google_base_url(preview=True)
 
 
 class TestGetHttpClient:

--- a/config.json
+++ b/config.json
@@ -187,7 +187,8 @@
             "from foundry_sdk.v2.language_models.utils import get_openai_base_url",
             "from foundry_sdk.v2.language_models.utils import get_anthropic_base_url",
             "from foundry_sdk.v2.language_models.utils import get_http_client",
-            "from foundry_sdk.v2.language_models.utils import get_async_http_client"
+            "from foundry_sdk.v2.language_models.utils import get_async_http_client",
+            "from foundry_sdk.v2.language_models.utils import get_google_base_url"
           ]
         },
         "MapRendering": false,


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
No LLM util exists to get the google base URL for use with Google's model SDK

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Defines `get_gogle_base_url` beta llm util
==COMMIT_MSG==


