### PR TITLE
Only set API_GATEWAY_VERSION if not already set

### DIFF
--- a/scripts/generate_spec.sh
+++ b/scripts/generate_spec.sh
@@ -6,7 +6,7 @@ MAVEN_REPO_PATH="$MAVEN_DIST_RELEASE/$(echo "$MAVEN_CONJURE_GROUP_ID" | sed 's/\
 
 mkdir -p $TMP_DIR
 
-if [ -z "$API_GATEWAY_VERSION" ]; then
+if [ -z "${API_GATEWAY_VERSION:-}" ]; then
     API_GATEWAY_VERSION=$( wget -q -O - "${MAVEN_REPO_PATH}/maven-metadata.xml" | \
         python scripts/parse_version.py )
 fi

--- a/scripts/generate_spec.sh
+++ b/scripts/generate_spec.sh
@@ -5,8 +5,11 @@ TMP_DIR=$SCRIPT_DIR/../tmp
 MAVEN_REPO_PATH="$MAVEN_DIST_RELEASE/$(echo "$MAVEN_CONJURE_GROUP_ID" | sed 's/\./\//g')/${MAVEN_CONJURE_ARTIFACT_ID}"
 
 mkdir -p $TMP_DIR
-API_GATEWAY_VERSION=$( wget -q -O - "${MAVEN_REPO_PATH}/maven-metadata.xml" | \
-    python scripts/parse_version.py )
+
+if [ -z "$API_GATEWAY_VERSION" ]; then
+    API_GATEWAY_VERSION=$( wget -q -O - "${MAVEN_REPO_PATH}/maven-metadata.xml" | \
+        python scripts/parse_version.py )
+fi
 
 echo Downloading $API_GATEWAY_VERSION...
 mkdir -p "${TMP_DIR}"


### PR DESCRIPTION
- **Only set API version if not already set**
- **Default to empty string**

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
`make spec` pulls the latest API spec. I've modified our excavator to set API_GATEWAY_VERSION to the STABLE_3 version instead.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Only set API version if not already set
==COMMIT_MSG==

Successful excavator run: https://github.com/palantir/foundry-platform-python/pull/350

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

