### PR TITLE
Make ObjectTypeV2.aliases optional

### DIFF
--- a/config.json
+++ b/config.json
@@ -241,6 +241,7 @@
     "InterfaceSharedPropertyType.typeClasses",
     "PropertyV2.typeClasses",
     "SharedPropertyType.typeClasses",
-    "StructFieldType.typeClasses"
+    "StructFieldType.typeClasses",
+    "ObjectTypeV2.aliases"
   ]
 }

--- a/docs/v2/Ontologies/models/ObjectTypeV2.md
+++ b/docs/v2/Ontologies/models/ObjectTypeV2.md
@@ -16,7 +16,7 @@ Represents an object type in the Ontology.
 **rid** | ObjectTypeRid | Yes |  |
 **title_property** | PropertyApiName | Yes |  |
 **visibility** | Optional[ObjectTypeVisibility] | No |  |
-**aliases** | List[str] | Yes | Alternative names (synonyms) for the object type, usable as search terms. This field is only populated on the get-by-RID read paths (e.g. `getObjectTypeV2`); it is always empty on the `listObjectTypesV2` endpoint.  |
+**aliases** | Optional[List[str]] | No | Alternative names (synonyms) for the object type, usable as search terms. This field is only populated on the get-by-RID read paths (e.g. `getObjectTypeV2`); it is always empty on the `listObjectTypesV2` endpoint.  |
 
 
 [[Back to Model list]](../../../../README.md#models-v2-link) [[Back to API list]](../../../../README.md#apis-v2-link) [[Back to README]](../../../../README.md)

--- a/foundry_sdk/v2/ontologies/models.py
+++ b/foundry_sdk/v2/ontologies/models.py
@@ -3640,7 +3640,7 @@ class ObjectTypeV2(core.ModelBase):
     rid: ObjectTypeRid
     title_property: PropertyApiName = pydantic.Field(alias=str("titleProperty"))  # type: ignore[literal-required]
     visibility: typing.Optional[ObjectTypeVisibility] = None
-    aliases: typing.List[str]
+    aliases: typing.Optional[typing.List[str]] = None
     """
     Alternative names (synonyms) for the object type, usable as search terms. This field is only populated on
     the get-by-RID read paths (e.g. `getObjectTypeV2`); it is always empty on the `listObjectTypesV2` endpoint.


### PR DESCRIPTION
## Before this PR
`aliases` was added to `ObjectTypeV2` as a required list, but it's only populated on the get-by-RID read paths and is empty on `listObjectTypesV2`. Required means any metadata that omits it fails to deserialize, which breaks consumers reading older or cached ontology metadata (e.g. the OSDK generator choking on a cached `ontology.json`).

## After this PR
`aliases` is optional (`Optional[List[str]] = None`) via the `optionalLists` config, same as `typeClasses` and friends. Payloads that don't include it now deserialize fine.

==COMMIT_MSG==
Make `ObjectTypeV2.aliases` optional
==COMMIT_MSG==

## Possible downsides?
The generated type changes from `List[str]` to `Optional[List[str]]`, so callers have to handle `None`. Low risk since `aliases` was only just added, but technically a signature change on that field.