### PR TITLE
Make ObjectTypeV2.datasources optional

### DIFF
--- a/config.json
+++ b/config.json
@@ -243,5 +243,6 @@
     "SharedPropertyType.typeClasses",
     "StructFieldType.typeClasses",
     "ObjectTypeV2.aliases"
+    "ObjectTypeV2.datasources"
   ]
 }


### PR DESCRIPTION
## Before this PR
`ObjectTypeV2.datasources` was not optional

## After this PR
`ObjectTypeV2.datasources` is optional