### PR TITLE
fix(aip_agents): resolve readonly attribute error on Agent property

### DIFF
--- a/changelog/@unreleased/fix-aip-agents-readonly-bug.yml
+++ b/changelog/@unreleased/fix-aip-agents-readonly-bug.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: "fix(aip_agents): resolve readonly attribute error on Agent property"
+  links:
+    - https://github.com/palantir/foundry-platform-python/issues/316

--- a/foundry_sdk/v2/aip_agents/_client.py
+++ b/foundry_sdk/v2/aip_agents/_client.py
@@ -43,11 +43,9 @@ class AipAgentsClient:
 
         self._config = config
 
-    @cached_property
-    def Agent(self):
         from foundry_sdk.v2.aip_agents.agent import AgentClient
 
-        return AgentClient(
+        self.Agent = AgentClient(
             auth=self._auth,
             hostname=self._hostname_supplier,
             config=self._config,

--- a/tests/test_aip_agents_client_patch.py
+++ b/tests/test_aip_agents_client_patch.py
@@ -3,16 +3,31 @@ from foundry_sdk.v2.aip_agents._client import AipAgentsClient
 from foundry_sdk.v2.client import FoundryClient
 from foundry_sdk._core import HostnameSupplier, Auth
 
+
 class DummyAuth(Auth):
-    def execute(self, *args, **kwargs): pass
-    def execute_with_token(self, *args, **kwargs): pass
-    def get_token(self, *args, **kwargs): return "dummy"
-    def run_with_token(self, *args, **kwargs): pass
+    def execute(self, *args, **kwargs):
+        pass
+
+    def execute_with_token(self, *args, **kwargs):
+        pass
+
+    def get_token(self, *args, **kwargs):
+        return "dummy"
+
+    def run_with_token(self, *args, **kwargs):
+        pass
+
 
 class DummyHostnameSupplier(HostnameSupplier):
-    def get_hostname(self): return "https://example.com"
-    def get_endpoint(self, endpoint_type): return "https://example.com"
-    def is_user_supplied(self): return True
+    def get_hostname(self):
+        return "https://example.com"
+
+    def get_endpoint(self, endpoint_type):
+        return "https://example.com"
+
+    def is_user_supplied(self):
+        return True
+
 
 def test_aip_agents_client_patch():
     auth = DummyAuth()
@@ -21,7 +36,7 @@ def test_aip_agents_client_patch():
 
     # Test direct AipAgentsClient instantiation
     client = AipAgentsClient(auth=auth, hostname=hostname, config=config)
-    
+
     # Verify we can access .Agent multiple times without descriptor errors
     assert hasattr(client, "Agent")
     agent_1 = client.Agent
@@ -30,10 +45,10 @@ def test_aip_agents_client_patch():
 
     # Test via FoundryClient to perfectly mirror user behavior
     foundry_client = FoundryClient(auth=auth, hostname=hostname)
-    
+
     # Ensure client.aip_agents.Agent returns True for hasattr
     assert hasattr(foundry_client.aip_agents, "Agent")
-    
+
     # Access multiple times to verify no errors
     foundry_agent_1 = foundry_client.aip_agents.Agent
     foundry_agent_2 = foundry_client.aip_agents.Agent

--- a/tests/test_aip_agents_client_patch.py
+++ b/tests/test_aip_agents_client_patch.py
@@ -1,0 +1,40 @@
+import pytest
+from foundry_sdk.v2.aip_agents._client import AipAgentsClient
+from foundry_sdk.v2.client import FoundryClient
+from foundry_sdk._core import HostnameSupplier, Auth
+
+class DummyAuth(Auth):
+    def execute(self, *args, **kwargs): pass
+    def execute_with_token(self, *args, **kwargs): pass
+    def get_token(self, *args, **kwargs): return "dummy"
+    def run_with_token(self, *args, **kwargs): pass
+
+class DummyHostnameSupplier(HostnameSupplier):
+    def get_hostname(self): return "https://example.com"
+    def get_endpoint(self, endpoint_type): return "https://example.com"
+    def is_user_supplied(self): return True
+
+def test_aip_agents_client_patch():
+    auth = DummyAuth()
+    hostname = "https://example.palantirfoundry.com"
+    config = None
+
+    # Test direct AipAgentsClient instantiation
+    client = AipAgentsClient(auth=auth, hostname=hostname, config=config)
+    
+    # Verify we can access .Agent multiple times without descriptor errors
+    assert hasattr(client, "Agent")
+    agent_1 = client.Agent
+    agent_2 = client.Agent
+    assert agent_1 is agent_2
+
+    # Test via FoundryClient to perfectly mirror user behavior
+    foundry_client = FoundryClient(auth=auth, hostname=hostname)
+    
+    # Ensure client.aip_agents.Agent returns True for hasattr
+    assert hasattr(foundry_client.aip_agents, "Agent")
+    
+    # Access multiple times to verify no errors
+    foundry_agent_1 = foundry_client.aip_agents.Agent
+    foundry_agent_2 = foundry_client.aip_agents.Agent
+    assert foundry_agent_1 is foundry_agent_2


### PR DESCRIPTION
## Before this PR
Resolves #316. 
Currently, users executing the documented AIP Agents API snippet (`client.aip_agents.Agent.Session.blocking_continue(...)`) encounter an `AttributeError: readonly attribute`. This occurs because the synchronous `AipAgentsClient` implements the `.Agent` property using `@cached_property`. As a non-data descriptor, `@cached_property` attempts to mutate the instance's `__dict__` upon first evaluation. In tightly controlled or frozen runtime environments (such as specific Foundry workspaces), this underlying dictionary mutation is blocked, resulting in a crash.

## After this PR
The synchronous `AipAgentsClient` now structurally matches the `AsyncAipAgentsClient` implementation. I removed the `@cached_property` descriptor and moved the `AgentClient` instantiation directly into the `__init__` method. This forces `Agent` to be a standard, eagerly evaluated instance attribute. This bypasses the descriptor protocol entirely, preventing the mutation crash while keeping the exact public-facing API contract intact. Users can now successfully execute the documented code snippets.

## Possible downsides?
Eager evaluation in `__init__` means `AgentClient` is instantiated when `AipAgentsClient` is created, rather than lazily upon first access. This introduces a negligible initialization overhead, but it perfectly aligns the sync client with the existing, proven behavior of the async client.