### PR TITLE
Generate federated v3 Platform SDK APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,11 @@ datetime_with_tz = datetime(2025, 2, 5, 20, 57, 57, 511182, tzinfo=timezone.utc)
 ```
 
 <a id="apis-link"></a>
+<a id="apis-v3-link"></a>
+## Documentation for V3 API endpoints
+
+Namespace | Resource | Operation | HTTP request |
+------------ | ------------- | ------------- | ------------- |
 <a id="apis-v2-link"></a>
 ## Documentation for V2 API endpoints
 
@@ -1018,6 +1023,25 @@ Namespace | Resource | Operation | HTTP request |
 
 
 <a id="models-link"></a>
+<a id="models-v3-link"></a>
+## Documentation for V3 models
+
+Namespace | Name | Import |
+--------- | ---- | ------ |
+**Core** | [PageSize](docs/v3/Core/models/PageSize.md) | `from foundry_sdk.v3.core.models import PageSize` |
+**Core** | [PageToken](docs/v3/Core/models/PageToken.md) | `from foundry_sdk.v3.core.models import PageToken` |
+**Endpoints** | [EndpointSet](docs/v3/Endpoints/models/EndpointSet.md) | `from foundry_sdk.v3.endpoints.models import EndpointSet` |
+**Endpoints** | [EndpointSetEndpoint](docs/v3/Endpoints/models/EndpointSetEndpoint.md) | `from foundry_sdk.v3.endpoints.models import EndpointSetEndpoint` |
+**Endpoints** | [EndpointSetEndpointRid](docs/v3/Endpoints/models/EndpointSetEndpointRid.md) | `from foundry_sdk.v3.endpoints.models import EndpointSetEndpointRid` |
+**Endpoints** | [EndpointSetRid](docs/v3/Endpoints/models/EndpointSetRid.md) | `from foundry_sdk.v3.endpoints.models import EndpointSetRid` |
+**Endpoints** | [EndpointSetVersion](docs/v3/Endpoints/models/EndpointSetVersion.md) | `from foundry_sdk.v3.endpoints.models import EndpointSetVersion` |
+**Endpoints** | [EndpointSetVersionId](docs/v3/Endpoints/models/EndpointSetVersionId.md) | `from foundry_sdk.v3.endpoints.models import EndpointSetVersionId` |
+**Endpoints** | [ListEndpointSetEndpointsResponse](docs/v3/Endpoints/models/ListEndpointSetEndpointsResponse.md) | `from foundry_sdk.v3.endpoints.models import ListEndpointSetEndpointsResponse` |
+**Endpoints** | [ListEndpointSetVersionsResponse](docs/v3/Endpoints/models/ListEndpointSetVersionsResponse.md) | `from foundry_sdk.v3.endpoints.models import ListEndpointSetVersionsResponse` |
+**Orchestrator** | [CompleteProcessExecutionSignalRequest](docs/v3/Orchestrator/models/CompleteProcessExecutionSignalRequest.md) | `from foundry_sdk.v3.orchestrator.models import CompleteProcessExecutionSignalRequest` |
+**Orchestrator** | [ProcessExecutionId](docs/v3/Orchestrator/models/ProcessExecutionId.md) | `from foundry_sdk.v3.orchestrator.models import ProcessExecutionId` |
+**Orchestrator** | [SignalId](docs/v3/Orchestrator/models/SignalId.md) | `from foundry_sdk.v3.orchestrator.models import SignalId` |
+
 <a id="models-v2-link"></a>
 ## Documentation for V2 models
 
@@ -3479,6 +3503,20 @@ Namespace | Name | Import |
 
 <a id="all-errors"></a>
 ## Documentation for errors
+<a id="errors-v3-link"></a>
+## Documentation for V3 errors
+
+Namespace | Name | Import |
+--------- | ---- | ------ |
+**Core** | BatchRequestSizeExceededLimit | `from foundry_sdk.v3.core.errors import BatchRequestSizeExceededLimit` |
+**Core** | MissingBatchRequest | `from foundry_sdk.v3.core.errors import MissingBatchRequest` |
+**Endpoints** | EndpointSetEndpointNotFound | `from foundry_sdk.v3.endpoints.errors import EndpointSetEndpointNotFound` |
+**Endpoints** | EndpointSetNotFound | `from foundry_sdk.v3.endpoints.errors import EndpointSetNotFound` |
+**Endpoints** | EndpointSetVersionNotFound | `from foundry_sdk.v3.endpoints.errors import EndpointSetVersionNotFound` |
+**Orchestrator** | CompleteProcessExecutionSignalPermissionDenied | `from foundry_sdk.v3.orchestrator.errors import CompleteProcessExecutionSignalPermissionDenied` |
+**Orchestrator** | ProcessExecutionExpired | `from foundry_sdk.v3.orchestrator.errors import ProcessExecutionExpired` |
+**Orchestrator** | ProcessExecutionNotFound | `from foundry_sdk.v3.orchestrator.errors import ProcessExecutionNotFound` |
+**Orchestrator** | ProcessExecutionSignalNotFound | `from foundry_sdk.v3.orchestrator.errors import ProcessExecutionSignalNotFound` |
 <a id="errors-v2-link"></a>
 ## Documentation for V2 errors
 

--- a/config.json
+++ b/config.json
@@ -227,6 +227,13 @@
         "parquetExperimentSeries",
         "parquetExperimentArtifactTable"
       ]
+    },
+    "v3": {
+      "namespaces": {
+        "Core": true,
+        "Endpoints": true,
+        "Orchestrator": true
+      }
     }
   },
   "optionalLists": [

--- a/docs-snippets-npm/package.json
+++ b/docs-snippets-npm/package.json
@@ -24,7 +24,7 @@
   "sls": {
     "dependencies": {
       "com.palantir.foundry.api:api-gateway": {
-        "minVersion": "1.1783.1",
+        "minVersion": "1.1786.0",
         "maxVersion": "1.x.x",
         "optional": false
       }

--- a/docs-snippets-npm/src/index.ts
+++ b/docs-snippets-npm/src/index.ts
@@ -2177,6 +2177,36 @@ export const PYTHON_PLATFORM_SNIPPETS: SdkSnippets<typeof PLATFORM_API_DOCS_SPEC
           {
             "template": "from foundry_sdk import FoundryClient\nimport foundry_sdk\nfrom pprint import pprint\n\nclient = FoundryClient(auth=foundry_sdk.UserTokenAuth(...), hostname=\"example.palantirfoundry.com\")\n\n# WidgetSetRid | A Resource Identifier (RID) identifying a widget set.\nwidget_set_rid = \"ri.widgetregistry..widget-set.21dt2c42-b7df-4b23-880b-1436a3dred2e\"\n# Optional[PreviewMode] | Enables the use of preview functionality.\npreview = None\n\n\ntry:\n    api_response = client.widgets.WidgetSet.get(widget_set_rid, preview=preview)\n    print(\"The get response:\\n\")\n    pprint(api_response)\nexcept foundry_sdk.PalantirRPCException as e:\n    print(\"HTTP error when calling WidgetSet.get: %s\\n\" % e)"
           }
+        ],
+        "v3.getEndpointSet": [
+          {
+            "template": "from foundry_sdk.v3 import FoundryClient\nimport foundry_sdk\nfrom pprint import pprint\n\nclient = FoundryClient(auth=foundry_sdk.UserTokenAuth(...), hostname=\"example.palantirfoundry.com\")\n\n# EndpointSetRid\nendpoint_set_rid = None\n\n\ntry:\n    api_response = client.endpoints.EndpointSet.get(endpoint_set_rid)\n    print(\"The get response:\\n\")\n    pprint(api_response)\nexcept foundry_sdk.PalantirRPCException as e:\n    print(\"HTTP error when calling EndpointSet.get: %s\\n\" % e)"
+          }
+        ],
+        "v3.getEndpointSetEndpoint": [
+          {
+            "template": "from foundry_sdk.v3 import FoundryClient\nimport foundry_sdk\nfrom pprint import pprint\n\nclient = FoundryClient(auth=foundry_sdk.UserTokenAuth(...), hostname=\"example.palantirfoundry.com\")\n\n# EndpointSetRid\nendpoint_set_rid = None\n# EndpointSetEndpointRid\nendpoint_rid = None\n\n\ntry:\n    api_response = client.endpoints.EndpointSet.Endpoint.get(endpoint_set_rid, endpoint_rid)\n    print(\"The get response:\\n\")\n    pprint(api_response)\nexcept foundry_sdk.PalantirRPCException as e:\n    print(\"HTTP error when calling Endpoint.get: %s\\n\" % e)"
+          }
+        ],
+        "v3.listEndpointSetEndpoints": [
+          {
+            "template": "from foundry_sdk.v3 import FoundryClient\nimport foundry_sdk\nfrom pprint import pprint\n\nclient = FoundryClient(auth=foundry_sdk.UserTokenAuth(...), hostname=\"example.palantirfoundry.com\")\n\n# EndpointSetRid\nendpoint_set_rid = None\n# Optional[PageSize]\npage_size = None\n# Optional[PageToken]\npage_token = None\n\n\ntry:\n    for endpoint_set_endpoint in client.endpoints.EndpointSet.Endpoint.list(\n        endpoint_set_rid, page_size=page_size, page_token=page_token\n    ):\n        pprint(endpoint_set_endpoint)\nexcept foundry_sdk.PalantirRPCException as e:\n    print(\"HTTP error when calling Endpoint.list: %s\\n\" % e)"
+          }
+        ],
+        "v3.getEndpointSetVersion": [
+          {
+            "template": "from foundry_sdk.v3 import FoundryClient\nimport foundry_sdk\nfrom pprint import pprint\n\nclient = FoundryClient(auth=foundry_sdk.UserTokenAuth(...), hostname=\"example.palantirfoundry.com\")\n\n# EndpointSetRid\nendpoint_set_rid = None\n# EndpointSetVersionId\nversion_id = None\n\n\ntry:\n    api_response = client.endpoints.EndpointSet.Version.get(endpoint_set_rid, version_id)\n    print(\"The get response:\\n\")\n    pprint(api_response)\nexcept foundry_sdk.PalantirRPCException as e:\n    print(\"HTTP error when calling Version.get: %s\\n\" % e)"
+          }
+        ],
+        "v3.listEndpointSetVersions": [
+          {
+            "template": "from foundry_sdk.v3 import FoundryClient\nimport foundry_sdk\nfrom pprint import pprint\n\nclient = FoundryClient(auth=foundry_sdk.UserTokenAuth(...), hostname=\"example.palantirfoundry.com\")\n\n# EndpointSetRid\nendpoint_set_rid = None\n# Optional[PageSize]\npage_size = None\n# Optional[PageToken]\npage_token = None\n\n\ntry:\n    for endpoint_set_version in client.endpoints.EndpointSet.Version.list(\n        endpoint_set_rid, page_size=page_size, page_token=page_token\n    ):\n        pprint(endpoint_set_version)\nexcept foundry_sdk.PalantirRPCException as e:\n    print(\"HTTP error when calling Version.list: %s\\n\" % e)"
+          }
+        ],
+        "v3.completeProcessExecutionSignal": [
+          {
+            "template": "from foundry_sdk.v3 import FoundryClient\nimport foundry_sdk\nfrom pprint import pprint\n\nclient = FoundryClient(auth=foundry_sdk.UserTokenAuth(...), hostname=\"example.palantirfoundry.com\")\n\n# ProcessExecutionId\nprocess_execution_id = None\n# SignalId\nsignal_id = None\n# Optional[Any] | Arbitrary JSON passed to the process execution that consumes the signal. Empty when the completion carries no payload.\npayload = None\n\n\ntry:\n    api_response = client.orchestrator.ProcessExecution.Signal.complete(\n        process_execution_id, signal_id, payload=payload\n    )\n    print(\"The complete response:\\n\")\n    pprint(api_response)\nexcept foundry_sdk.PalantirRPCException as e:\n    print(\"HTTP error when calling Signal.complete: %s\\n\" % e)"
+          }
         ]
       }
     }

--- a/docs/v2/Ontologies/ActionTypeFullMetadata.md
+++ b/docs/v2/Ontologies/ActionTypeFullMetadata.md
@@ -208,7 +208,7 @@ See [README](../../../README.md#authorization)
 Search for action types in the given Ontology that match the provided filters. Full action type metadata
 results are returned by relevance of the match unless an explicit `orderBy` is provided.
 
-Action types with logic rules that cannot be represented in the API are omitted from the results. 
+Action types with logic rules that cannot be represented in the API are omitted from the results.
 As a consequence, totalCount counts all matching action types in the Ontology and may exceed the number
 of results returned across all pages, and an individual page may be empty even when nextPageToken is present.
 
@@ -286,4 +286,3 @@ See [README](../../../README.md#authorization)
 **200** | SearchActionTypesFullMetadataResponse  | Success response. | application/json |
 
 [[Back to top]](#) [[Back to API list]](../../../README.md#apis-v2-link) [[Back to Model list]](../../../README.md#models-v2-link) [[Back to README]](../../../README.md)
-

--- a/docs/v3/Core/models/PageSize.md
+++ b/docs/v3/Core/models/PageSize.md
@@ -1,0 +1,11 @@
+# PageSize
+
+PageSize
+
+## Type
+```python
+int
+```
+
+
+[[Back to Model list]](../../../../README.md#models-v3-link) [[Back to API list]](../../../../README.md#apis-v3-link) [[Back to README]](../../../../README.md)

--- a/docs/v3/Core/models/PageToken.md
+++ b/docs/v3/Core/models/PageToken.md
@@ -1,0 +1,11 @@
+# PageToken
+
+PageToken
+
+## Type
+```python
+str
+```
+
+
+[[Back to Model list]](../../../../README.md#models-v3-link) [[Back to API list]](../../../../README.md#apis-v3-link) [[Back to README]](../../../../README.md)

--- a/docs/v3/Endpoints/EndpointSet.md
+++ b/docs/v3/Endpoints/EndpointSet.md
@@ -1,0 +1,52 @@
+# EndpointSet
+
+Method | HTTP request | Release Stage |
+------------- | ------------- | ----- |
+[**get**](#get) | **GET** /v3/platform/endpointSets/{endpointSetRid} | Private Beta |
+
+# **get**
+
+
+### Parameters
+
+Name | Type | Description  | Notes |
+------------- | ------------- | ------------- | ------------- |
+**endpoint_set_rid** | EndpointSetRid |  |  |
+
+### Return type
+**EndpointSet**
+
+### Example
+
+```python
+from foundry_sdk.v3 import FoundryClient
+import foundry_sdk
+from pprint import pprint
+
+client = FoundryClient(auth=foundry_sdk.UserTokenAuth(...), hostname="example.palantirfoundry.com")
+
+# EndpointSetRid
+endpoint_set_rid = None
+
+
+try:
+    api_response = client.endpoints.EndpointSet.get(endpoint_set_rid)
+    print("The get response:\n")
+    pprint(api_response)
+except foundry_sdk.PalantirRPCException as e:
+    print("HTTP error when calling EndpointSet.get: %s\n" % e)
+
+```
+
+
+
+### Authorization
+
+See [README](../../../README.md#authorization)
+
+### HTTP response details
+| Status Code | Type        | Description | Content Type |
+|-------------|-------------|-------------|------------------|
+**200** | EndpointSet  |  | application/json |
+
+[[Back to top]](#) [[Back to API list]](../../../README.md#apis-v3-link) [[Back to Model list]](../../../README.md#models-v3-link) [[Back to README]](../../../README.md)

--- a/docs/v3/Endpoints/EndpointSetEndpoint.md
+++ b/docs/v3/Endpoints/EndpointSetEndpoint.md
@@ -1,0 +1,109 @@
+# EndpointSetEndpoint
+
+Method | HTTP request | Release Stage |
+------------- | ------------- | ----- |
+[**get**](#get) | **GET** /v3/platform/endpointSets/{endpointSetRid}/endpoints/{endpointRid} | Private Beta |
+[**list**](#list) | **GET** /v3/platform/endpointSets/{endpointSetRid}/endpoints | Private Beta |
+
+# **get**
+
+
+### Parameters
+
+Name | Type | Description  | Notes |
+------------- | ------------- | ------------- | ------------- |
+**endpoint_set_rid** | EndpointSetRid |  |  |
+**endpoint_rid** | EndpointSetEndpointRid |  |  |
+
+### Return type
+**EndpointSetEndpoint**
+
+### Example
+
+```python
+from foundry_sdk.v3 import FoundryClient
+import foundry_sdk
+from pprint import pprint
+
+client = FoundryClient(auth=foundry_sdk.UserTokenAuth(...), hostname="example.palantirfoundry.com")
+
+# EndpointSetRid
+endpoint_set_rid = None
+# EndpointSetEndpointRid
+endpoint_rid = None
+
+
+try:
+    api_response = client.endpoints.EndpointSet.Endpoint.get(endpoint_set_rid, endpoint_rid)
+    print("The get response:\n")
+    pprint(api_response)
+except foundry_sdk.PalantirRPCException as e:
+    print("HTTP error when calling Endpoint.get: %s\n" % e)
+
+```
+
+
+
+### Authorization
+
+See [README](../../../README.md#authorization)
+
+### HTTP response details
+| Status Code | Type        | Description | Content Type |
+|-------------|-------------|-------------|------------------|
+**200** | EndpointSetEndpoint  |  | application/json |
+
+[[Back to top]](#) [[Back to API list]](../../../README.md#apis-v3-link) [[Back to Model list]](../../../README.md#models-v3-link) [[Back to README]](../../../README.md)
+# **list**
+
+
+### Parameters
+
+Name | Type | Description  | Notes |
+------------- | ------------- | ------------- | ------------- |
+**endpoint_set_rid** | EndpointSetRid |  |  |
+**page_size** | Optional[PageSize] |  | [optional] |
+**page_token** | Optional[PageToken] |  | [optional] |
+
+### Return type
+**ListEndpointSetEndpointsResponse**
+
+### Example
+
+```python
+from foundry_sdk.v3 import FoundryClient
+import foundry_sdk
+from pprint import pprint
+
+client = FoundryClient(auth=foundry_sdk.UserTokenAuth(...), hostname="example.palantirfoundry.com")
+
+# EndpointSetRid
+endpoint_set_rid = None
+# Optional[PageSize]
+page_size = None
+# Optional[PageToken]
+page_token = None
+
+
+try:
+    for endpoint_set_endpoint in client.endpoints.EndpointSet.Endpoint.list(
+        endpoint_set_rid, page_size=page_size, page_token=page_token
+    ):
+        pprint(endpoint_set_endpoint)
+except foundry_sdk.PalantirRPCException as e:
+    print("HTTP error when calling Endpoint.list: %s\n" % e)
+
+```
+
+
+
+### Authorization
+
+See [README](../../../README.md#authorization)
+
+### HTTP response details
+| Status Code | Type        | Description | Content Type |
+|-------------|-------------|-------------|------------------|
+**200** | ListEndpointSetEndpointsResponse  |  | application/json |
+
+[[Back to top]](#) [[Back to API list]](../../../README.md#apis-v3-link) [[Back to Model list]](../../../README.md#models-v3-link) [[Back to README]](../../../README.md)

--- a/docs/v3/Endpoints/EndpointSetVersion.md
+++ b/docs/v3/Endpoints/EndpointSetVersion.md
@@ -1,0 +1,109 @@
+# EndpointSetVersion
+
+Method | HTTP request | Release Stage |
+------------- | ------------- | ----- |
+[**get**](#get) | **GET** /v3/platform/endpointSets/{endpointSetRid}/versions/{versionId} | Private Beta |
+[**list**](#list) | **GET** /v3/platform/endpointSets/{endpointSetRid}/versions | Private Beta |
+
+# **get**
+
+
+### Parameters
+
+Name | Type | Description  | Notes |
+------------- | ------------- | ------------- | ------------- |
+**endpoint_set_rid** | EndpointSetRid |  |  |
+**version_id** | EndpointSetVersionId |  |  |
+
+### Return type
+**EndpointSetVersion**
+
+### Example
+
+```python
+from foundry_sdk.v3 import FoundryClient
+import foundry_sdk
+from pprint import pprint
+
+client = FoundryClient(auth=foundry_sdk.UserTokenAuth(...), hostname="example.palantirfoundry.com")
+
+# EndpointSetRid
+endpoint_set_rid = None
+# EndpointSetVersionId
+version_id = None
+
+
+try:
+    api_response = client.endpoints.EndpointSet.Version.get(endpoint_set_rid, version_id)
+    print("The get response:\n")
+    pprint(api_response)
+except foundry_sdk.PalantirRPCException as e:
+    print("HTTP error when calling Version.get: %s\n" % e)
+
+```
+
+
+
+### Authorization
+
+See [README](../../../README.md#authorization)
+
+### HTTP response details
+| Status Code | Type        | Description | Content Type |
+|-------------|-------------|-------------|------------------|
+**200** | EndpointSetVersion  |  | application/json |
+
+[[Back to top]](#) [[Back to API list]](../../../README.md#apis-v3-link) [[Back to Model list]](../../../README.md#models-v3-link) [[Back to README]](../../../README.md)
+# **list**
+
+
+### Parameters
+
+Name | Type | Description  | Notes |
+------------- | ------------- | ------------- | ------------- |
+**endpoint_set_rid** | EndpointSetRid |  |  |
+**page_size** | Optional[PageSize] |  | [optional] |
+**page_token** | Optional[PageToken] |  | [optional] |
+
+### Return type
+**ListEndpointSetVersionsResponse**
+
+### Example
+
+```python
+from foundry_sdk.v3 import FoundryClient
+import foundry_sdk
+from pprint import pprint
+
+client = FoundryClient(auth=foundry_sdk.UserTokenAuth(...), hostname="example.palantirfoundry.com")
+
+# EndpointSetRid
+endpoint_set_rid = None
+# Optional[PageSize]
+page_size = None
+# Optional[PageToken]
+page_token = None
+
+
+try:
+    for endpoint_set_version in client.endpoints.EndpointSet.Version.list(
+        endpoint_set_rid, page_size=page_size, page_token=page_token
+    ):
+        pprint(endpoint_set_version)
+except foundry_sdk.PalantirRPCException as e:
+    print("HTTP error when calling Version.list: %s\n" % e)
+
+```
+
+
+
+### Authorization
+
+See [README](../../../README.md#authorization)
+
+### HTTP response details
+| Status Code | Type        | Description | Content Type |
+|-------------|-------------|-------------|------------------|
+**200** | ListEndpointSetVersionsResponse  |  | application/json |
+
+[[Back to top]](#) [[Back to API list]](../../../README.md#apis-v3-link) [[Back to Model list]](../../../README.md#models-v3-link) [[Back to README]](../../../README.md)

--- a/docs/v3/Endpoints/models/EndpointSet.md
+++ b/docs/v3/Endpoints/models/EndpointSet.md
@@ -1,0 +1,12 @@
+# EndpointSet
+
+EndpointSet
+
+## Properties
+| Name | Type | Required | Description |
+| ------------ | ------------- | ------------- | ------------- |
+**name** | str | Yes |  |
+**rid** | EndpointSetRid | Yes |  |
+
+
+[[Back to Model list]](../../../../README.md#models-v3-link) [[Back to API list]](../../../../README.md#apis-v3-link) [[Back to README]](../../../../README.md)

--- a/docs/v3/Endpoints/models/EndpointSetEndpoint.md
+++ b/docs/v3/Endpoints/models/EndpointSetEndpoint.md
@@ -1,0 +1,12 @@
+# EndpointSetEndpoint
+
+EndpointSetEndpoint
+
+## Properties
+| Name | Type | Required | Description |
+| ------------ | ------------- | ------------- | ------------- |
+**name** | str | Yes |  |
+**rid** | EndpointSetEndpointRid | Yes |  |
+
+
+[[Back to Model list]](../../../../README.md#models-v3-link) [[Back to API list]](../../../../README.md#apis-v3-link) [[Back to README]](../../../../README.md)

--- a/docs/v3/Endpoints/models/EndpointSetEndpointRid.md
+++ b/docs/v3/Endpoints/models/EndpointSetEndpointRid.md
@@ -1,0 +1,11 @@
+# EndpointSetEndpointRid
+
+EndpointSetEndpointRid
+
+## Type
+```python
+RID
+```
+
+
+[[Back to Model list]](../../../../README.md#models-v3-link) [[Back to API list]](../../../../README.md#apis-v3-link) [[Back to README]](../../../../README.md)

--- a/docs/v3/Endpoints/models/EndpointSetRid.md
+++ b/docs/v3/Endpoints/models/EndpointSetRid.md
@@ -1,0 +1,11 @@
+# EndpointSetRid
+
+EndpointSetRid
+
+## Type
+```python
+RID
+```
+
+
+[[Back to Model list]](../../../../README.md#models-v3-link) [[Back to API list]](../../../../README.md#apis-v3-link) [[Back to README]](../../../../README.md)

--- a/docs/v3/Endpoints/models/EndpointSetVersion.md
+++ b/docs/v3/Endpoints/models/EndpointSetVersion.md
@@ -1,0 +1,11 @@
+# EndpointSetVersion
+
+EndpointSetVersion
+
+## Properties
+| Name | Type | Required | Description |
+| ------------ | ------------- | ------------- | ------------- |
+**id** | EndpointSetVersionId | Yes |  |
+
+
+[[Back to Model list]](../../../../README.md#models-v3-link) [[Back to API list]](../../../../README.md#apis-v3-link) [[Back to README]](../../../../README.md)

--- a/docs/v3/Endpoints/models/EndpointSetVersionId.md
+++ b/docs/v3/Endpoints/models/EndpointSetVersionId.md
@@ -1,0 +1,11 @@
+# EndpointSetVersionId
+
+EndpointSetVersionId
+
+## Type
+```python
+str
+```
+
+
+[[Back to Model list]](../../../../README.md#models-v3-link) [[Back to API list]](../../../../README.md#apis-v3-link) [[Back to README]](../../../../README.md)

--- a/docs/v3/Endpoints/models/ListEndpointSetEndpointsResponse.md
+++ b/docs/v3/Endpoints/models/ListEndpointSetEndpointsResponse.md
@@ -1,0 +1,12 @@
+# ListEndpointSetEndpointsResponse
+
+ListEndpointSetEndpointsResponse
+
+## Properties
+| Name | Type | Required | Description |
+| ------------ | ------------- | ------------- | ------------- |
+**data** | List[EndpointSetEndpoint] | Yes |  |
+**next_page_token** | Optional[PageToken] | No |  |
+
+
+[[Back to Model list]](../../../../README.md#models-v3-link) [[Back to API list]](../../../../README.md#apis-v3-link) [[Back to README]](../../../../README.md)

--- a/docs/v3/Endpoints/models/ListEndpointSetVersionsResponse.md
+++ b/docs/v3/Endpoints/models/ListEndpointSetVersionsResponse.md
@@ -1,0 +1,12 @@
+# ListEndpointSetVersionsResponse
+
+ListEndpointSetVersionsResponse
+
+## Properties
+| Name | Type | Required | Description |
+| ------------ | ------------- | ------------- | ------------- |
+**data** | List[EndpointSetVersion] | Yes |  |
+**next_page_token** | Optional[PageToken] | No |  |
+
+
+[[Back to Model list]](../../../../README.md#models-v3-link) [[Back to API list]](../../../../README.md#apis-v3-link) [[Back to README]](../../../../README.md)

--- a/docs/v3/Orchestrator/ProcessExecution.md
+++ b/docs/v3/Orchestrator/ProcessExecution.md
@@ -1,0 +1,4 @@
+# ProcessExecution
+
+Method | HTTP request | Release Stage |
+------------- | ------------- | ----- |

--- a/docs/v3/Orchestrator/ProcessExecutionSignal.md
+++ b/docs/v3/Orchestrator/ProcessExecutionSignal.md
@@ -1,0 +1,65 @@
+# ProcessExecutionSignal
+
+Method | HTTP request | Release Stage |
+------------- | ------------- | ----- |
+[**complete**](#complete) | **POST** /v3/platform/processExecutions/{processExecutionId}/signals/{signalId}/complete | Private Beta |
+
+# **complete**
+Complete a signal on a process execution.
+
+A signal may be completed multiple times, each contributing toward the execution's wait conditions.
+If the execution is suspended waiting on this signal, it resumes once its wait conditions are
+satisfied. Resuming an execution runs user-authored logic. Only the token that originally invoked the
+process execution can complete its signals.
+
+### Parameters
+
+Name | Type | Description  | Notes |
+------------- | ------------- | ------------- | ------------- |
+**process_execution_id** | ProcessExecutionId |  |  |
+**signal_id** | SignalId |  |  |
+**payload** | Optional[Any] | Arbitrary JSON passed to the process execution that consumes the signal. Empty when the completion carries no payload. | [optional] |
+
+### Return type
+**None**
+
+### Example
+
+```python
+from foundry_sdk.v3 import FoundryClient
+import foundry_sdk
+from pprint import pprint
+
+client = FoundryClient(auth=foundry_sdk.UserTokenAuth(...), hostname="example.palantirfoundry.com")
+
+# ProcessExecutionId
+process_execution_id = None
+# SignalId
+signal_id = None
+# Optional[Any] | Arbitrary JSON passed to the process execution that consumes the signal. Empty when the completion carries no payload.
+payload = None
+
+
+try:
+    api_response = client.orchestrator.ProcessExecution.Signal.complete(
+        process_execution_id, signal_id, payload=payload
+    )
+    print("The complete response:\n")
+    pprint(api_response)
+except foundry_sdk.PalantirRPCException as e:
+    print("HTTP error when calling Signal.complete: %s\n" % e)
+
+```
+
+
+
+### Authorization
+
+See [README](../../../README.md#authorization)
+
+### HTTP response details
+| Status Code | Type        | Description | Content Type |
+|-------------|-------------|-------------|------------------|
+**204** | None  |  | None |
+
+[[Back to top]](#) [[Back to API list]](../../../README.md#apis-v3-link) [[Back to Model list]](../../../README.md#models-v3-link) [[Back to README]](../../../README.md)

--- a/docs/v3/Orchestrator/models/CompleteProcessExecutionSignalRequest.md
+++ b/docs/v3/Orchestrator/models/CompleteProcessExecutionSignalRequest.md
@@ -1,0 +1,11 @@
+# CompleteProcessExecutionSignalRequest
+
+The data to attach to a signal completion.
+
+## Properties
+| Name | Type | Required | Description |
+| ------------ | ------------- | ------------- | ------------- |
+**payload** | Optional[Any] | No | Arbitrary JSON passed to the process execution that consumes the signal. Empty when the completion carries no payload. |
+
+
+[[Back to Model list]](../../../../README.md#models-v3-link) [[Back to API list]](../../../../README.md#apis-v3-link) [[Back to README]](../../../../README.md)

--- a/docs/v3/Orchestrator/models/ProcessExecutionId.md
+++ b/docs/v3/Orchestrator/models/ProcessExecutionId.md
@@ -1,0 +1,11 @@
+# ProcessExecutionId
+
+Identifies a single execution of a durable process run by the platform.
+
+## Type
+```python
+str
+```
+
+
+[[Back to Model list]](../../../../README.md#models-v3-link) [[Back to API list]](../../../../README.md#apis-v3-link) [[Back to README]](../../../../README.md)

--- a/docs/v3/Orchestrator/models/SignalId.md
+++ b/docs/v3/Orchestrator/models/SignalId.md
@@ -1,0 +1,11 @@
+# SignalId
+
+Identifies a signal on a process execution.
+
+## Type
+```python
+str
+```
+
+
+[[Back to Model list]](../../../../README.md#models-v3-link) [[Back to API list]](../../../../README.md#apis-v3-link) [[Back to README]](../../../../README.md)

--- a/foundry_sdk/v3/__init__.py
+++ b/foundry_sdk/v3/__init__.py
@@ -13,8 +13,9 @@
 #  limitations under the License.
 
 
-# The version is set during the publishing step (since we can't know the version in advance)
-# using the autorelease bot
-__version__ = "0.0.0"
+from foundry_sdk.v3.client import AsyncFoundryClient, FoundryClient
 
-__openapi_document_version__ = "1.1786.0"
+__all__ = [
+    "FoundryClient",
+    "AsyncFoundryClient",
+]

--- a/foundry_sdk/v3/cli.py
+++ b/foundry_sdk/v3/cli.py
@@ -1,0 +1,217 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+from __future__ import annotations
+
+import dataclasses
+import io
+import json
+import os
+import typing
+from datetime import date as Date
+from datetime import datetime
+
+import click
+
+from foundry_sdk import EnvironmentNotConfigured, UserTokenAuth
+from foundry_sdk.v3 import FoundryClient
+
+
+@dataclasses.dataclass
+class _Context:
+    obj: FoundryClient
+
+
+def get_from_environ(key: str) -> str:
+    value = os.environ.get(key)
+    if value is None:
+        raise EnvironmentNotConfigured(f"Please set {key} using `export {key}=<{key}>`")
+
+    return value
+
+
+@click.group()  # type: ignore
+@click.pass_context  # type: ignore
+def cli(ctx: _Context):
+    """An experimental CLI for the Foundry API"""
+    ctx.obj = FoundryClient(
+        auth=UserTokenAuth(token=get_from_environ("FOUNDRY_TOKEN")),
+        hostname=get_from_environ("FOUNDRY_HOSTNAME"),
+    )
+
+
+@cli.group("core")
+def core():
+    pass
+
+
+@cli.group("endpoints")
+def endpoints():
+    pass
+
+
+@endpoints.group("endpoint_set")
+def endpoints_endpoint_set():
+    pass
+
+
+@endpoints_endpoint_set.command("get")
+@click.argument("endpoint_set_rid", type=str, required=True)
+@click.pass_obj
+def endpoints_endpoint_set_op_get(
+    client: FoundryClient,
+    endpoint_set_rid: str,
+):
+    """ """
+    result = client.endpoints.EndpointSet.get(
+        endpoint_set_rid=endpoint_set_rid,
+    )
+    click.echo(repr(result))
+
+
+@endpoints_endpoint_set.group("endpoint_set_version")
+def endpoints_endpoint_set_endpoint_set_version():
+    pass
+
+
+@endpoints_endpoint_set_endpoint_set_version.command("get")
+@click.argument("endpoint_set_rid", type=str, required=True)
+@click.argument("version_id", type=str, required=True)
+@click.pass_obj
+def endpoints_endpoint_set_endpoint_set_version_op_get(
+    client: FoundryClient,
+    endpoint_set_rid: str,
+    version_id: str,
+):
+    """ """
+    result = client.endpoints.EndpointSet.Version.get(
+        endpoint_set_rid=endpoint_set_rid,
+        version_id=version_id,
+    )
+    click.echo(repr(result))
+
+
+@endpoints_endpoint_set_endpoint_set_version.command("list")
+@click.argument("endpoint_set_rid", type=str, required=True)
+@click.option("--page_size", type=int, required=False, help="""""")
+@click.option("--page_token", type=str, required=False, help="""""")
+@click.pass_obj
+def endpoints_endpoint_set_endpoint_set_version_op_list(
+    client: FoundryClient,
+    endpoint_set_rid: str,
+    page_size: typing.Optional[int],
+    page_token: typing.Optional[str],
+):
+    """ """
+    result = client.endpoints.EndpointSet.Version.list(
+        endpoint_set_rid=endpoint_set_rid,
+        page_size=page_size,
+        page_token=page_token,
+    )
+    click.echo(repr(result))
+
+
+@endpoints_endpoint_set.group("endpoint_set_endpoint")
+def endpoints_endpoint_set_endpoint_set_endpoint():
+    pass
+
+
+@endpoints_endpoint_set_endpoint_set_endpoint.command("get")
+@click.argument("endpoint_set_rid", type=str, required=True)
+@click.argument("endpoint_rid", type=str, required=True)
+@click.pass_obj
+def endpoints_endpoint_set_endpoint_set_endpoint_op_get(
+    client: FoundryClient,
+    endpoint_set_rid: str,
+    endpoint_rid: str,
+):
+    """ """
+    result = client.endpoints.EndpointSet.Endpoint.get(
+        endpoint_set_rid=endpoint_set_rid,
+        endpoint_rid=endpoint_rid,
+    )
+    click.echo(repr(result))
+
+
+@endpoints_endpoint_set_endpoint_set_endpoint.command("list")
+@click.argument("endpoint_set_rid", type=str, required=True)
+@click.option("--page_size", type=int, required=False, help="""""")
+@click.option("--page_token", type=str, required=False, help="""""")
+@click.pass_obj
+def endpoints_endpoint_set_endpoint_set_endpoint_op_list(
+    client: FoundryClient,
+    endpoint_set_rid: str,
+    page_size: typing.Optional[int],
+    page_token: typing.Optional[str],
+):
+    """ """
+    result = client.endpoints.EndpointSet.Endpoint.list(
+        endpoint_set_rid=endpoint_set_rid,
+        page_size=page_size,
+        page_token=page_token,
+    )
+    click.echo(repr(result))
+
+
+@cli.group("orchestrator")
+def orchestrator():
+    pass
+
+
+@orchestrator.group("process_execution")
+def orchestrator_process_execution():
+    pass
+
+
+@orchestrator_process_execution.group("process_execution_signal")
+def orchestrator_process_execution_process_execution_signal():
+    pass
+
+
+@orchestrator_process_execution_process_execution_signal.command("complete")
+@click.argument("process_execution_id", type=str, required=True)
+@click.argument("signal_id", type=str, required=True)
+@click.option(
+    "--payload",
+    type=str,
+    required=False,
+    help="""Arbitrary JSON passed to the process execution that consumes the signal. Empty when the completion
+carries no payload.""",
+)
+@click.pass_obj
+def orchestrator_process_execution_process_execution_signal_op_complete(
+    client: FoundryClient,
+    process_execution_id: str,
+    signal_id: str,
+    payload: typing.Optional[str],
+):
+    """
+    Complete a signal on a process execution.
+
+    A signal may be completed multiple times, each contributing toward the execution's wait conditions.
+    If the execution is suspended waiting on this signal, it resumes once its wait conditions are
+    satisfied. Resuming an execution runs user-authored logic. Only the token that originally invoked the
+    process execution can complete its signals.
+    """
+    result = client.orchestrator.ProcessExecution.Signal.complete(
+        process_execution_id=process_execution_id,
+        signal_id=signal_id,
+        payload=None if payload is None else json.loads(payload),
+    )
+    click.echo(repr(result))
+
+
+if __name__ == "__main__":
+    cli()

--- a/foundry_sdk/v3/client.py
+++ b/foundry_sdk/v3/client.py
@@ -1,0 +1,84 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import typing
+
+from foundry_sdk import _core as core
+from foundry_sdk._core.client_init_helpers import (
+    create_hostname_supplier,
+    get_user_token_auth_from_context_or_environment_vars,
+)
+
+
+class FoundryClient:
+    """
+    The Foundry V3 API client.
+
+    :param auth: Required. Your auth configuration.
+    :param hostname: Required. Your Foundry hostname (for example, "myfoundry.palantirfoundry.com"). This can also include your API gateway service URI.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: typing.Optional[core.Auth] = None,
+        hostname: typing.Optional[str] = None,
+        config: typing.Optional[core.Config] = None,
+    ):
+        if auth is None:
+            auth = get_user_token_auth_from_context_or_environment_vars()
+
+        hostname_supplier = create_hostname_supplier(hostname, config)
+
+        from foundry_sdk.v3.endpoints._client import EndpointsClient
+        from foundry_sdk.v3.orchestrator._client import OrchestratorClient
+
+        self.endpoints = EndpointsClient(auth=auth, hostname=hostname_supplier, config=config)
+        self.orchestrator = OrchestratorClient(auth=auth, hostname=hostname_supplier, config=config)
+
+
+class AsyncFoundryClient:
+    """
+    The Async Foundry V3 API client.
+
+    :param auth: Required. Your auth configuration.
+    :param hostname: Required. Your Foundry hostname (for example, "myfoundry.palantirfoundry.com"). This can also include your API gateway service URI.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: typing.Optional[core.Auth] = None,
+        hostname: typing.Optional[str] = None,
+        config: typing.Optional[core.Config] = None,
+        preview: bool = False,
+    ):
+        if not preview:
+            raise ValueError(
+                "The AsyncFoundryClient client is in beta. "
+                "Please set the preview parameter to True to use it."
+            )
+        if auth is None:
+            auth = get_user_token_auth_from_context_or_environment_vars()
+
+        hostname_supplier = create_hostname_supplier(hostname, config)
+
+        from foundry_sdk.v3.endpoints._client import AsyncEndpointsClient
+        from foundry_sdk.v3.orchestrator._client import AsyncOrchestratorClient
+
+        self.endpoints = AsyncEndpointsClient(auth=auth, hostname=hostname_supplier, config=config)
+        self.orchestrator = AsyncOrchestratorClient(
+            auth=auth, hostname=hostname_supplier, config=config
+        )

--- a/foundry_sdk/v3/core/errors.py
+++ b/foundry_sdk/v3/core/errors.py
@@ -1,0 +1,54 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import typing
+from dataclasses import dataclass
+
+import typing_extensions
+
+from foundry_sdk import _errors as errors
+
+
+class BatchRequestSizeExceededLimitParameters(typing_extensions.TypedDict):
+
+    __pydantic_config__ = {"extra": "allow"}  # type: ignore
+
+    maximumBatchSize: int
+    providedBatchSize: int
+
+
+@dataclass
+class BatchRequestSizeExceededLimit(errors.BadRequestError):
+    name: typing.Literal["BatchRequestSizeExceededLimit"]
+    parameters: BatchRequestSizeExceededLimitParameters
+    error_instance_id: str
+
+
+class MissingBatchRequestParameters(typing_extensions.TypedDict):
+
+    __pydantic_config__ = {"extra": "allow"}  # type: ignore
+
+
+@dataclass
+class MissingBatchRequest(errors.BadRequestError):
+    name: typing.Literal["MissingBatchRequest"]
+    parameters: MissingBatchRequestParameters
+    error_instance_id: str
+
+
+__all__ = [
+    "BatchRequestSizeExceededLimit",
+    "MissingBatchRequest",
+]

--- a/foundry_sdk/v3/core/models.py
+++ b/foundry_sdk/v3/core/models.py
@@ -13,8 +13,24 @@
 #  limitations under the License.
 
 
-# The version is set during the publishing step (since we can't know the version in advance)
-# using the autorelease bot
-__version__ = "0.0.0"
+from __future__ import annotations
 
-__openapi_document_version__ = "1.1786.0"
+import pydantic
+import typing_extensions
+
+from foundry_sdk import _core as core
+
+PageSize: typing_extensions.TypeAlias = int
+"""PageSize"""
+
+
+PageToken: typing_extensions.TypeAlias = str
+"""PageToken"""
+
+
+core.resolve_forward_references_in_module(__name__)
+
+__all__ = [
+    "PageSize",
+    "PageToken",
+]

--- a/foundry_sdk/v3/endpoints/__init__.py
+++ b/foundry_sdk/v3/endpoints/__init__.py
@@ -13,8 +13,9 @@
 #  limitations under the License.
 
 
-# The version is set during the publishing step (since we can't know the version in advance)
-# using the autorelease bot
-__version__ = "0.0.0"
+from foundry_sdk.v3.endpoints._client import AsyncEndpointsClient, EndpointsClient
 
-__openapi_document_version__ = "1.1786.0"
+__all__ = [
+    "EndpointsClient",
+    "AsyncEndpointsClient",
+]

--- a/foundry_sdk/v3/endpoints/_client.py
+++ b/foundry_sdk/v3/endpoints/_client.py
@@ -1,0 +1,74 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import typing
+from functools import cached_property
+
+from foundry_sdk import _core as core
+
+
+class EndpointsClient:
+    """
+    The API client for the Endpoints Namespace.
+
+    :param auth: Your auth configuration.
+    :param hostname: The hostname supplier for resolving base URLs.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: core.Auth,
+        hostname: typing.Union[str, core.HostnameSupplier],
+        config: typing.Optional[core.Config] = None,
+    ):
+        self._auth = auth
+        if isinstance(hostname, core.HostnameSupplier):
+            self._hostname_supplier = hostname
+        else:
+            self._hostname_supplier = core.create_hostname_supplier(hostname, config)
+        self._hostname = self._hostname_supplier.get_hostname()
+
+        self._config = config
+
+    @cached_property
+    def EndpointSet(self):
+        from foundry_sdk.v3.endpoints.endpoint_set import EndpointSetClient
+
+        return EndpointSetClient(
+            auth=self._auth,
+            hostname=self._hostname_supplier,
+            config=self._config,
+        )
+
+
+class AsyncEndpointsClient:
+    """
+    The Async API client for the Endpoints Namespace.
+
+    :param auth: Your auth configuration.
+    :param hostname: The hostname supplier for resolving base URLs.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: core.Auth,
+        hostname: typing.Union[str, core.HostnameSupplier],
+        config: typing.Optional[core.Config] = None,
+    ):
+        from foundry_sdk.v3.endpoints.endpoint_set import AsyncEndpointSetClient
+
+        self.EndpointSet = AsyncEndpointSetClient(auth=auth, hostname=hostname, config=config)

--- a/foundry_sdk/v3/endpoints/endpoint_set.py
+++ b/foundry_sdk/v3/endpoints/endpoint_set.py
@@ -1,0 +1,247 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import typing
+from functools import cached_property
+
+import pydantic
+import typing_extensions
+
+from foundry_sdk import _core as core
+from foundry_sdk import _errors as errors
+from foundry_sdk.v3.endpoints import errors as endpoints_errors
+from foundry_sdk.v3.endpoints import models as endpoints_models
+
+
+class EndpointSetClient:
+    """
+    The API client for the EndpointSet Resource.
+
+    :param auth: Your auth configuration.
+    :param hostname: The hostname supplier for resolving base URLs.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: core.Auth,
+        hostname: typing.Union[str, core.HostnameSupplier],
+        config: typing.Optional[core.Config] = None,
+    ):
+        self._auth = auth
+        if isinstance(hostname, core.HostnameSupplier):
+            self._hostname_supplier = hostname
+        else:
+            self._hostname_supplier = core.create_hostname_supplier(hostname, config)
+        self._hostname = self._hostname_supplier.get_hostname()
+        self._config = config
+        self._api_client = core.ApiClient(
+            auth=auth, hostname=self._hostname_supplier, config=config
+        )
+
+        self.with_streaming_response = _EndpointSetClientStreaming(self)
+        self.with_raw_response = _EndpointSetClientRaw(self)
+
+    @cached_property
+    def Endpoint(self):
+        from foundry_sdk.v3.endpoints.endpoint_set_endpoint import (
+            EndpointSetEndpointClient,
+        )
+
+        return EndpointSetEndpointClient(
+            auth=self._auth,
+            hostname=self._hostname_supplier,
+            config=self._config,
+        )
+
+    @cached_property
+    def Version(self):
+        from foundry_sdk.v3.endpoints.endpoint_set_version import (
+            EndpointSetVersionClient,
+        )
+
+        return EndpointSetVersionClient(
+            auth=self._auth,
+            hostname=self._hostname_supplier,
+            config=self._config,
+        )
+
+    @core.maybe_ignore_preview
+    @pydantic.validate_call
+    @errors.handle_unexpected
+    def get(
+        self,
+        endpoint_set_rid: endpoints_models.EndpointSetRid,
+        *,
+        request_timeout: typing.Optional[core.Timeout] = None,
+        _sdk_internal: core.SdkInternal = {},
+    ) -> endpoints_models.EndpointSet:
+        """
+
+        :param endpoint_set_rid:
+        :type endpoint_set_rid: EndpointSetRid
+        :param request_timeout: timeout setting for this request in seconds.
+        :type request_timeout: Optional[int]
+        :return: Returns the result object.
+        :rtype: endpoints_models.EndpointSet
+
+        :raises EndpointSetNotFound:
+        """
+
+        return self._api_client.call_api(
+            core.RequestInfo(
+                method="GET",
+                resource_path="/v3/platform/endpointSets/{endpointSetRid}",
+                query_params={},
+                path_params={
+                    "endpointSetRid": endpoint_set_rid,
+                },
+                header_params={
+                    "Accept": "application/json",
+                },
+                body=None,
+                response_type=endpoints_models.EndpointSet,
+                request_timeout=request_timeout,
+                throwable_errors={
+                    "EndpointSetNotFound": endpoints_errors.EndpointSetNotFound,
+                },
+                response_mode=_sdk_internal.get("response_mode"),
+            ),
+        )
+
+
+class _EndpointSetClientRaw:
+    def __init__(self, client: EndpointSetClient) -> None:
+        def get(_: endpoints_models.EndpointSet): ...
+
+        self.get = core.with_raw_response(get, client.get)
+
+
+class _EndpointSetClientStreaming:
+    def __init__(self, client: EndpointSetClient) -> None:
+        def get(_: endpoints_models.EndpointSet): ...
+
+        self.get = core.with_streaming_response(get, client.get)
+
+
+class AsyncEndpointSetClient:
+    """
+    The API client for the EndpointSet Resource.
+
+    :param auth: Your auth configuration.
+    :param hostname: The hostname supplier for resolving base URLs.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: core.Auth,
+        hostname: typing.Union[str, core.HostnameSupplier],
+        config: typing.Optional[core.Config] = None,
+    ):
+        self._auth = auth
+        if isinstance(hostname, core.HostnameSupplier):
+            self._hostname_supplier = hostname
+        else:
+            self._hostname_supplier = core.create_hostname_supplier(hostname, config)
+        self._hostname = self._hostname_supplier.get_hostname()
+        self._config = config
+        self._api_client = core.AsyncApiClient(
+            auth=auth, hostname=self._hostname_supplier, config=config
+        )
+
+        self.with_streaming_response = _AsyncEndpointSetClientStreaming(self)
+        self.with_raw_response = _AsyncEndpointSetClientRaw(self)
+
+    @cached_property
+    def Endpoint(self):
+        from foundry_sdk.v3.endpoints.endpoint_set_endpoint import (
+            AsyncEndpointSetEndpointClient,
+        )
+
+        return AsyncEndpointSetEndpointClient(
+            auth=self._auth,
+            hostname=self._hostname_supplier,
+            config=self._config,
+        )
+
+    @cached_property
+    def Version(self):
+        from foundry_sdk.v3.endpoints.endpoint_set_version import (
+            AsyncEndpointSetVersionClient,
+        )
+
+        return AsyncEndpointSetVersionClient(
+            auth=self._auth,
+            hostname=self._hostname_supplier,
+            config=self._config,
+        )
+
+    @core.maybe_ignore_preview
+    @pydantic.validate_call
+    @errors.handle_unexpected
+    def get(
+        self,
+        endpoint_set_rid: endpoints_models.EndpointSetRid,
+        *,
+        request_timeout: typing.Optional[core.Timeout] = None,
+        _sdk_internal: core.SdkInternal = {},
+    ) -> typing.Awaitable[endpoints_models.EndpointSet]:
+        """
+
+        :param endpoint_set_rid:
+        :type endpoint_set_rid: EndpointSetRid
+        :param request_timeout: timeout setting for this request in seconds.
+        :type request_timeout: Optional[int]
+        :return: Returns the result object.
+        :rtype: typing.Awaitable[endpoints_models.EndpointSet]
+
+        :raises EndpointSetNotFound:
+        """
+
+        return self._api_client.call_api(
+            core.RequestInfo(
+                method="GET",
+                resource_path="/v3/platform/endpointSets/{endpointSetRid}",
+                query_params={},
+                path_params={
+                    "endpointSetRid": endpoint_set_rid,
+                },
+                header_params={
+                    "Accept": "application/json",
+                },
+                body=None,
+                response_type=endpoints_models.EndpointSet,
+                request_timeout=request_timeout,
+                throwable_errors={
+                    "EndpointSetNotFound": endpoints_errors.EndpointSetNotFound,
+                },
+                response_mode=_sdk_internal.get("response_mode"),
+            ),
+        )
+
+
+class _AsyncEndpointSetClientRaw:
+    def __init__(self, client: AsyncEndpointSetClient) -> None:
+        def get(_: endpoints_models.EndpointSet): ...
+
+        self.get = core.async_with_raw_response(get, client.get)
+
+
+class _AsyncEndpointSetClientStreaming:
+    def __init__(self, client: AsyncEndpointSetClient) -> None:
+        def get(_: endpoints_models.EndpointSet): ...
+
+        self.get = core.async_with_streaming_response(get, client.get)

--- a/foundry_sdk/v3/endpoints/endpoint_set_endpoint.py
+++ b/foundry_sdk/v3/endpoints/endpoint_set_endpoint.py
@@ -1,0 +1,323 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import typing
+
+import pydantic
+import typing_extensions
+
+from foundry_sdk import _core as core
+from foundry_sdk import _errors as errors
+from foundry_sdk.v3.core import models as core_models
+from foundry_sdk.v3.endpoints import errors as endpoints_errors
+from foundry_sdk.v3.endpoints import models as endpoints_models
+
+
+class EndpointSetEndpointClient:
+    """
+    The API client for the EndpointSetEndpoint Resource.
+
+    :param auth: Your auth configuration.
+    :param hostname: The hostname supplier for resolving base URLs.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: core.Auth,
+        hostname: typing.Union[str, core.HostnameSupplier],
+        config: typing.Optional[core.Config] = None,
+    ):
+        self._auth = auth
+        if isinstance(hostname, core.HostnameSupplier):
+            self._hostname_supplier = hostname
+        else:
+            self._hostname_supplier = core.create_hostname_supplier(hostname, config)
+        self._hostname = self._hostname_supplier.get_hostname()
+        self._config = config
+        self._api_client = core.ApiClient(
+            auth=auth, hostname=self._hostname_supplier, config=config
+        )
+
+        self.with_streaming_response = _EndpointSetEndpointClientStreaming(self)
+        self.with_raw_response = _EndpointSetEndpointClientRaw(self)
+
+    @core.maybe_ignore_preview
+    @pydantic.validate_call
+    @errors.handle_unexpected
+    def get(
+        self,
+        endpoint_set_rid: endpoints_models.EndpointSetRid,
+        endpoint_rid: endpoints_models.EndpointSetEndpointRid,
+        *,
+        request_timeout: typing.Optional[core.Timeout] = None,
+        _sdk_internal: core.SdkInternal = {},
+    ) -> endpoints_models.EndpointSetEndpoint:
+        """
+
+        :param endpoint_set_rid:
+        :type endpoint_set_rid: EndpointSetRid
+        :param endpoint_rid:
+        :type endpoint_rid: EndpointSetEndpointRid
+        :param request_timeout: timeout setting for this request in seconds.
+        :type request_timeout: Optional[int]
+        :return: Returns the result object.
+        :rtype: endpoints_models.EndpointSetEndpoint
+
+        :raises EndpointSetEndpointNotFound:
+        :raises EndpointSetNotFound:
+        """
+
+        return self._api_client.call_api(
+            core.RequestInfo(
+                method="GET",
+                resource_path="/v3/platform/endpointSets/{endpointSetRid}/endpoints/{endpointRid}",
+                query_params={},
+                path_params={
+                    "endpointSetRid": endpoint_set_rid,
+                    "endpointRid": endpoint_rid,
+                },
+                header_params={
+                    "Accept": "application/json",
+                },
+                body=None,
+                response_type=endpoints_models.EndpointSetEndpoint,
+                request_timeout=request_timeout,
+                throwable_errors={
+                    "EndpointSetEndpointNotFound": endpoints_errors.EndpointSetEndpointNotFound,
+                    "EndpointSetNotFound": endpoints_errors.EndpointSetNotFound,
+                },
+                response_mode=_sdk_internal.get("response_mode"),
+            ),
+        )
+
+    @core.maybe_ignore_preview
+    @pydantic.validate_call
+    @errors.handle_unexpected
+    def list(
+        self,
+        endpoint_set_rid: endpoints_models.EndpointSetRid,
+        *,
+        page_size: typing.Optional[core_models.PageSize] = None,
+        page_token: typing.Optional[core_models.PageToken] = None,
+        request_timeout: typing.Optional[core.Timeout] = None,
+        _sdk_internal: core.SdkInternal = {},
+    ) -> core.ResourceIterator[endpoints_models.EndpointSetEndpoint]:
+        """
+
+        :param endpoint_set_rid:
+        :type endpoint_set_rid: EndpointSetRid
+        :param page_size:
+        :type page_size: Optional[PageSize]
+        :param page_token:
+        :type page_token: Optional[PageToken]
+        :param request_timeout: timeout setting for this request in seconds.
+        :type request_timeout: Optional[int]
+        :return: Returns the result object.
+        :rtype: core.ResourceIterator[endpoints_models.EndpointSetEndpoint]
+
+        :raises EndpointSetNotFound:
+        """
+
+        return self._api_client.call_api(
+            core.RequestInfo(
+                method="GET",
+                resource_path="/v3/platform/endpointSets/{endpointSetRid}/endpoints",
+                query_params={
+                    "pageSize": page_size,
+                    "pageToken": page_token,
+                },
+                path_params={
+                    "endpointSetRid": endpoint_set_rid,
+                },
+                header_params={
+                    "Accept": "application/json",
+                },
+                body=None,
+                response_type=endpoints_models.ListEndpointSetEndpointsResponse,
+                request_timeout=request_timeout,
+                throwable_errors={
+                    "EndpointSetNotFound": endpoints_errors.EndpointSetNotFound,
+                },
+                response_mode=_sdk_internal.get("response_mode", "ITERATOR"),
+            ),
+        )
+
+
+class _EndpointSetEndpointClientRaw:
+    def __init__(self, client: EndpointSetEndpointClient) -> None:
+        def get(_: endpoints_models.EndpointSetEndpoint): ...
+        def list(_: endpoints_models.ListEndpointSetEndpointsResponse): ...
+
+        self.get = core.with_raw_response(get, client.get)
+        self.list = core.with_raw_response(list, client.list)
+
+
+class _EndpointSetEndpointClientStreaming:
+    def __init__(self, client: EndpointSetEndpointClient) -> None:
+        def get(_: endpoints_models.EndpointSetEndpoint): ...
+        def list(_: endpoints_models.ListEndpointSetEndpointsResponse): ...
+
+        self.get = core.with_streaming_response(get, client.get)
+        self.list = core.with_streaming_response(list, client.list)
+
+
+class AsyncEndpointSetEndpointClient:
+    """
+    The API client for the EndpointSetEndpoint Resource.
+
+    :param auth: Your auth configuration.
+    :param hostname: The hostname supplier for resolving base URLs.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: core.Auth,
+        hostname: typing.Union[str, core.HostnameSupplier],
+        config: typing.Optional[core.Config] = None,
+    ):
+        self._auth = auth
+        if isinstance(hostname, core.HostnameSupplier):
+            self._hostname_supplier = hostname
+        else:
+            self._hostname_supplier = core.create_hostname_supplier(hostname, config)
+        self._hostname = self._hostname_supplier.get_hostname()
+        self._config = config
+        self._api_client = core.AsyncApiClient(
+            auth=auth, hostname=self._hostname_supplier, config=config
+        )
+
+        self.with_streaming_response = _AsyncEndpointSetEndpointClientStreaming(self)
+        self.with_raw_response = _AsyncEndpointSetEndpointClientRaw(self)
+
+    @core.maybe_ignore_preview
+    @pydantic.validate_call
+    @errors.handle_unexpected
+    def get(
+        self,
+        endpoint_set_rid: endpoints_models.EndpointSetRid,
+        endpoint_rid: endpoints_models.EndpointSetEndpointRid,
+        *,
+        request_timeout: typing.Optional[core.Timeout] = None,
+        _sdk_internal: core.SdkInternal = {},
+    ) -> typing.Awaitable[endpoints_models.EndpointSetEndpoint]:
+        """
+
+        :param endpoint_set_rid:
+        :type endpoint_set_rid: EndpointSetRid
+        :param endpoint_rid:
+        :type endpoint_rid: EndpointSetEndpointRid
+        :param request_timeout: timeout setting for this request in seconds.
+        :type request_timeout: Optional[int]
+        :return: Returns the result object.
+        :rtype: typing.Awaitable[endpoints_models.EndpointSetEndpoint]
+
+        :raises EndpointSetEndpointNotFound:
+        :raises EndpointSetNotFound:
+        """
+
+        return self._api_client.call_api(
+            core.RequestInfo(
+                method="GET",
+                resource_path="/v3/platform/endpointSets/{endpointSetRid}/endpoints/{endpointRid}",
+                query_params={},
+                path_params={
+                    "endpointSetRid": endpoint_set_rid,
+                    "endpointRid": endpoint_rid,
+                },
+                header_params={
+                    "Accept": "application/json",
+                },
+                body=None,
+                response_type=endpoints_models.EndpointSetEndpoint,
+                request_timeout=request_timeout,
+                throwable_errors={
+                    "EndpointSetEndpointNotFound": endpoints_errors.EndpointSetEndpointNotFound,
+                    "EndpointSetNotFound": endpoints_errors.EndpointSetNotFound,
+                },
+                response_mode=_sdk_internal.get("response_mode"),
+            ),
+        )
+
+    @core.maybe_ignore_preview
+    @pydantic.validate_call
+    @errors.handle_unexpected
+    def list(
+        self,
+        endpoint_set_rid: endpoints_models.EndpointSetRid,
+        *,
+        page_size: typing.Optional[core_models.PageSize] = None,
+        page_token: typing.Optional[core_models.PageToken] = None,
+        request_timeout: typing.Optional[core.Timeout] = None,
+        _sdk_internal: core.SdkInternal = {},
+    ) -> core.AsyncResourceIterator[endpoints_models.EndpointSetEndpoint]:
+        """
+
+        :param endpoint_set_rid:
+        :type endpoint_set_rid: EndpointSetRid
+        :param page_size:
+        :type page_size: Optional[PageSize]
+        :param page_token:
+        :type page_token: Optional[PageToken]
+        :param request_timeout: timeout setting for this request in seconds.
+        :type request_timeout: Optional[int]
+        :return: Returns the result object.
+        :rtype: core.AsyncResourceIterator[endpoints_models.EndpointSetEndpoint]
+
+        :raises EndpointSetNotFound:
+        """
+
+        return self._api_client.call_api(
+            core.RequestInfo(
+                method="GET",
+                resource_path="/v3/platform/endpointSets/{endpointSetRid}/endpoints",
+                query_params={
+                    "pageSize": page_size,
+                    "pageToken": page_token,
+                },
+                path_params={
+                    "endpointSetRid": endpoint_set_rid,
+                },
+                header_params={
+                    "Accept": "application/json",
+                },
+                body=None,
+                response_type=endpoints_models.ListEndpointSetEndpointsResponse,
+                request_timeout=request_timeout,
+                throwable_errors={
+                    "EndpointSetNotFound": endpoints_errors.EndpointSetNotFound,
+                },
+                response_mode=_sdk_internal.get("response_mode", "ITERATOR"),
+            ),
+        )
+
+
+class _AsyncEndpointSetEndpointClientRaw:
+    def __init__(self, client: AsyncEndpointSetEndpointClient) -> None:
+        def get(_: endpoints_models.EndpointSetEndpoint): ...
+        def list(_: endpoints_models.ListEndpointSetEndpointsResponse): ...
+
+        self.get = core.async_with_raw_response(get, client.get)
+        self.list = core.async_with_raw_response(list, client.list)
+
+
+class _AsyncEndpointSetEndpointClientStreaming:
+    def __init__(self, client: AsyncEndpointSetEndpointClient) -> None:
+        def get(_: endpoints_models.EndpointSetEndpoint): ...
+        def list(_: endpoints_models.ListEndpointSetEndpointsResponse): ...
+
+        self.get = core.async_with_streaming_response(get, client.get)
+        self.list = core.async_with_streaming_response(list, client.list)

--- a/foundry_sdk/v3/endpoints/endpoint_set_version.py
+++ b/foundry_sdk/v3/endpoints/endpoint_set_version.py
@@ -1,0 +1,323 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import typing
+
+import pydantic
+import typing_extensions
+
+from foundry_sdk import _core as core
+from foundry_sdk import _errors as errors
+from foundry_sdk.v3.core import models as core_models
+from foundry_sdk.v3.endpoints import errors as endpoints_errors
+from foundry_sdk.v3.endpoints import models as endpoints_models
+
+
+class EndpointSetVersionClient:
+    """
+    The API client for the EndpointSetVersion Resource.
+
+    :param auth: Your auth configuration.
+    :param hostname: The hostname supplier for resolving base URLs.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: core.Auth,
+        hostname: typing.Union[str, core.HostnameSupplier],
+        config: typing.Optional[core.Config] = None,
+    ):
+        self._auth = auth
+        if isinstance(hostname, core.HostnameSupplier):
+            self._hostname_supplier = hostname
+        else:
+            self._hostname_supplier = core.create_hostname_supplier(hostname, config)
+        self._hostname = self._hostname_supplier.get_hostname()
+        self._config = config
+        self._api_client = core.ApiClient(
+            auth=auth, hostname=self._hostname_supplier, config=config
+        )
+
+        self.with_streaming_response = _EndpointSetVersionClientStreaming(self)
+        self.with_raw_response = _EndpointSetVersionClientRaw(self)
+
+    @core.maybe_ignore_preview
+    @pydantic.validate_call
+    @errors.handle_unexpected
+    def get(
+        self,
+        endpoint_set_rid: endpoints_models.EndpointSetRid,
+        version_id: endpoints_models.EndpointSetVersionId,
+        *,
+        request_timeout: typing.Optional[core.Timeout] = None,
+        _sdk_internal: core.SdkInternal = {},
+    ) -> endpoints_models.EndpointSetVersion:
+        """
+
+        :param endpoint_set_rid:
+        :type endpoint_set_rid: EndpointSetRid
+        :param version_id:
+        :type version_id: EndpointSetVersionId
+        :param request_timeout: timeout setting for this request in seconds.
+        :type request_timeout: Optional[int]
+        :return: Returns the result object.
+        :rtype: endpoints_models.EndpointSetVersion
+
+        :raises EndpointSetNotFound:
+        :raises EndpointSetVersionNotFound:
+        """
+
+        return self._api_client.call_api(
+            core.RequestInfo(
+                method="GET",
+                resource_path="/v3/platform/endpointSets/{endpointSetRid}/versions/{versionId}",
+                query_params={},
+                path_params={
+                    "endpointSetRid": endpoint_set_rid,
+                    "versionId": version_id,
+                },
+                header_params={
+                    "Accept": "application/json",
+                },
+                body=None,
+                response_type=endpoints_models.EndpointSetVersion,
+                request_timeout=request_timeout,
+                throwable_errors={
+                    "EndpointSetNotFound": endpoints_errors.EndpointSetNotFound,
+                    "EndpointSetVersionNotFound": endpoints_errors.EndpointSetVersionNotFound,
+                },
+                response_mode=_sdk_internal.get("response_mode"),
+            ),
+        )
+
+    @core.maybe_ignore_preview
+    @pydantic.validate_call
+    @errors.handle_unexpected
+    def list(
+        self,
+        endpoint_set_rid: endpoints_models.EndpointSetRid,
+        *,
+        page_size: typing.Optional[core_models.PageSize] = None,
+        page_token: typing.Optional[core_models.PageToken] = None,
+        request_timeout: typing.Optional[core.Timeout] = None,
+        _sdk_internal: core.SdkInternal = {},
+    ) -> core.ResourceIterator[endpoints_models.EndpointSetVersion]:
+        """
+
+        :param endpoint_set_rid:
+        :type endpoint_set_rid: EndpointSetRid
+        :param page_size:
+        :type page_size: Optional[PageSize]
+        :param page_token:
+        :type page_token: Optional[PageToken]
+        :param request_timeout: timeout setting for this request in seconds.
+        :type request_timeout: Optional[int]
+        :return: Returns the result object.
+        :rtype: core.ResourceIterator[endpoints_models.EndpointSetVersion]
+
+        :raises EndpointSetNotFound:
+        """
+
+        return self._api_client.call_api(
+            core.RequestInfo(
+                method="GET",
+                resource_path="/v3/platform/endpointSets/{endpointSetRid}/versions",
+                query_params={
+                    "pageSize": page_size,
+                    "pageToken": page_token,
+                },
+                path_params={
+                    "endpointSetRid": endpoint_set_rid,
+                },
+                header_params={
+                    "Accept": "application/json",
+                },
+                body=None,
+                response_type=endpoints_models.ListEndpointSetVersionsResponse,
+                request_timeout=request_timeout,
+                throwable_errors={
+                    "EndpointSetNotFound": endpoints_errors.EndpointSetNotFound,
+                },
+                response_mode=_sdk_internal.get("response_mode", "ITERATOR"),
+            ),
+        )
+
+
+class _EndpointSetVersionClientRaw:
+    def __init__(self, client: EndpointSetVersionClient) -> None:
+        def get(_: endpoints_models.EndpointSetVersion): ...
+        def list(_: endpoints_models.ListEndpointSetVersionsResponse): ...
+
+        self.get = core.with_raw_response(get, client.get)
+        self.list = core.with_raw_response(list, client.list)
+
+
+class _EndpointSetVersionClientStreaming:
+    def __init__(self, client: EndpointSetVersionClient) -> None:
+        def get(_: endpoints_models.EndpointSetVersion): ...
+        def list(_: endpoints_models.ListEndpointSetVersionsResponse): ...
+
+        self.get = core.with_streaming_response(get, client.get)
+        self.list = core.with_streaming_response(list, client.list)
+
+
+class AsyncEndpointSetVersionClient:
+    """
+    The API client for the EndpointSetVersion Resource.
+
+    :param auth: Your auth configuration.
+    :param hostname: The hostname supplier for resolving base URLs.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: core.Auth,
+        hostname: typing.Union[str, core.HostnameSupplier],
+        config: typing.Optional[core.Config] = None,
+    ):
+        self._auth = auth
+        if isinstance(hostname, core.HostnameSupplier):
+            self._hostname_supplier = hostname
+        else:
+            self._hostname_supplier = core.create_hostname_supplier(hostname, config)
+        self._hostname = self._hostname_supplier.get_hostname()
+        self._config = config
+        self._api_client = core.AsyncApiClient(
+            auth=auth, hostname=self._hostname_supplier, config=config
+        )
+
+        self.with_streaming_response = _AsyncEndpointSetVersionClientStreaming(self)
+        self.with_raw_response = _AsyncEndpointSetVersionClientRaw(self)
+
+    @core.maybe_ignore_preview
+    @pydantic.validate_call
+    @errors.handle_unexpected
+    def get(
+        self,
+        endpoint_set_rid: endpoints_models.EndpointSetRid,
+        version_id: endpoints_models.EndpointSetVersionId,
+        *,
+        request_timeout: typing.Optional[core.Timeout] = None,
+        _sdk_internal: core.SdkInternal = {},
+    ) -> typing.Awaitable[endpoints_models.EndpointSetVersion]:
+        """
+
+        :param endpoint_set_rid:
+        :type endpoint_set_rid: EndpointSetRid
+        :param version_id:
+        :type version_id: EndpointSetVersionId
+        :param request_timeout: timeout setting for this request in seconds.
+        :type request_timeout: Optional[int]
+        :return: Returns the result object.
+        :rtype: typing.Awaitable[endpoints_models.EndpointSetVersion]
+
+        :raises EndpointSetNotFound:
+        :raises EndpointSetVersionNotFound:
+        """
+
+        return self._api_client.call_api(
+            core.RequestInfo(
+                method="GET",
+                resource_path="/v3/platform/endpointSets/{endpointSetRid}/versions/{versionId}",
+                query_params={},
+                path_params={
+                    "endpointSetRid": endpoint_set_rid,
+                    "versionId": version_id,
+                },
+                header_params={
+                    "Accept": "application/json",
+                },
+                body=None,
+                response_type=endpoints_models.EndpointSetVersion,
+                request_timeout=request_timeout,
+                throwable_errors={
+                    "EndpointSetNotFound": endpoints_errors.EndpointSetNotFound,
+                    "EndpointSetVersionNotFound": endpoints_errors.EndpointSetVersionNotFound,
+                },
+                response_mode=_sdk_internal.get("response_mode"),
+            ),
+        )
+
+    @core.maybe_ignore_preview
+    @pydantic.validate_call
+    @errors.handle_unexpected
+    def list(
+        self,
+        endpoint_set_rid: endpoints_models.EndpointSetRid,
+        *,
+        page_size: typing.Optional[core_models.PageSize] = None,
+        page_token: typing.Optional[core_models.PageToken] = None,
+        request_timeout: typing.Optional[core.Timeout] = None,
+        _sdk_internal: core.SdkInternal = {},
+    ) -> core.AsyncResourceIterator[endpoints_models.EndpointSetVersion]:
+        """
+
+        :param endpoint_set_rid:
+        :type endpoint_set_rid: EndpointSetRid
+        :param page_size:
+        :type page_size: Optional[PageSize]
+        :param page_token:
+        :type page_token: Optional[PageToken]
+        :param request_timeout: timeout setting for this request in seconds.
+        :type request_timeout: Optional[int]
+        :return: Returns the result object.
+        :rtype: core.AsyncResourceIterator[endpoints_models.EndpointSetVersion]
+
+        :raises EndpointSetNotFound:
+        """
+
+        return self._api_client.call_api(
+            core.RequestInfo(
+                method="GET",
+                resource_path="/v3/platform/endpointSets/{endpointSetRid}/versions",
+                query_params={
+                    "pageSize": page_size,
+                    "pageToken": page_token,
+                },
+                path_params={
+                    "endpointSetRid": endpoint_set_rid,
+                },
+                header_params={
+                    "Accept": "application/json",
+                },
+                body=None,
+                response_type=endpoints_models.ListEndpointSetVersionsResponse,
+                request_timeout=request_timeout,
+                throwable_errors={
+                    "EndpointSetNotFound": endpoints_errors.EndpointSetNotFound,
+                },
+                response_mode=_sdk_internal.get("response_mode", "ITERATOR"),
+            ),
+        )
+
+
+class _AsyncEndpointSetVersionClientRaw:
+    def __init__(self, client: AsyncEndpointSetVersionClient) -> None:
+        def get(_: endpoints_models.EndpointSetVersion): ...
+        def list(_: endpoints_models.ListEndpointSetVersionsResponse): ...
+
+        self.get = core.async_with_raw_response(get, client.get)
+        self.list = core.async_with_raw_response(list, client.list)
+
+
+class _AsyncEndpointSetVersionClientStreaming:
+    def __init__(self, client: AsyncEndpointSetVersionClient) -> None:
+        def get(_: endpoints_models.EndpointSetVersion): ...
+        def list(_: endpoints_models.ListEndpointSetVersionsResponse): ...
+
+        self.get = core.async_with_streaming_response(get, client.get)
+        self.list = core.async_with_streaming_response(list, client.list)

--- a/foundry_sdk/v3/endpoints/errors.py
+++ b/foundry_sdk/v3/endpoints/errors.py
@@ -1,0 +1,73 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import typing
+from dataclasses import dataclass
+
+import typing_extensions
+
+from foundry_sdk import _errors as errors
+from foundry_sdk.v3.endpoints import models as endpoints_models
+
+
+class EndpointSetEndpointNotFoundParameters(typing_extensions.TypedDict):
+
+    __pydantic_config__ = {"extra": "allow"}  # type: ignore
+
+    endpointRid: endpoints_models.EndpointSetEndpointRid
+    endpointSetRid: endpoints_models.EndpointSetRid
+
+
+@dataclass
+class EndpointSetEndpointNotFound(errors.NotFoundError):
+    name: typing.Literal["EndpointSetEndpointNotFound"]
+    parameters: EndpointSetEndpointNotFoundParameters
+    error_instance_id: str
+
+
+class EndpointSetNotFoundParameters(typing_extensions.TypedDict):
+
+    __pydantic_config__ = {"extra": "allow"}  # type: ignore
+
+    endpointSetRid: endpoints_models.EndpointSetRid
+
+
+@dataclass
+class EndpointSetNotFound(errors.NotFoundError):
+    name: typing.Literal["EndpointSetNotFound"]
+    parameters: EndpointSetNotFoundParameters
+    error_instance_id: str
+
+
+class EndpointSetVersionNotFoundParameters(typing_extensions.TypedDict):
+
+    __pydantic_config__ = {"extra": "allow"}  # type: ignore
+
+    versionId: endpoints_models.EndpointSetVersionId
+    endpointSetRid: endpoints_models.EndpointSetRid
+
+
+@dataclass
+class EndpointSetVersionNotFound(errors.NotFoundError):
+    name: typing.Literal["EndpointSetVersionNotFound"]
+    parameters: EndpointSetVersionNotFoundParameters
+    error_instance_id: str
+
+
+__all__ = [
+    "EndpointSetEndpointNotFound",
+    "EndpointSetNotFound",
+    "EndpointSetVersionNotFound",
+]

--- a/foundry_sdk/v3/endpoints/models.py
+++ b/foundry_sdk/v3/endpoints/models.py
@@ -1,0 +1,84 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+from __future__ import annotations
+
+import typing
+
+import pydantic
+import typing_extensions
+
+from foundry_sdk import _core as core
+from foundry_sdk.v3.core import models as core_models
+
+
+class EndpointSet(core.ModelBase):
+    """EndpointSet"""
+
+    name: str
+    rid: EndpointSetRid
+
+
+class EndpointSetEndpoint(core.ModelBase):
+    """EndpointSetEndpoint"""
+
+    name: str
+    rid: EndpointSetEndpointRid
+
+
+EndpointSetEndpointRid: typing_extensions.TypeAlias = core.RID
+"""EndpointSetEndpointRid"""
+
+
+EndpointSetRid: typing_extensions.TypeAlias = core.RID
+"""EndpointSetRid"""
+
+
+class EndpointSetVersion(core.ModelBase):
+    """EndpointSetVersion"""
+
+    id: EndpointSetVersionId
+
+
+EndpointSetVersionId: typing_extensions.TypeAlias = str
+"""EndpointSetVersionId"""
+
+
+class ListEndpointSetEndpointsResponse(core.ModelBase):
+    """ListEndpointSetEndpointsResponse"""
+
+    data: typing.List[EndpointSetEndpoint]
+    next_page_token: typing.Optional[core_models.PageToken] = pydantic.Field(alias=str("nextPageToken"), default=None)  # type: ignore[literal-required]
+
+
+class ListEndpointSetVersionsResponse(core.ModelBase):
+    """ListEndpointSetVersionsResponse"""
+
+    data: typing.List[EndpointSetVersion]
+    next_page_token: typing.Optional[core_models.PageToken] = pydantic.Field(alias=str("nextPageToken"), default=None)  # type: ignore[literal-required]
+
+
+core.resolve_forward_references_in_module(__name__)
+
+__all__ = [
+    "EndpointSet",
+    "EndpointSetEndpoint",
+    "EndpointSetEndpointRid",
+    "EndpointSetRid",
+    "EndpointSetVersion",
+    "EndpointSetVersionId",
+    "ListEndpointSetEndpointsResponse",
+    "ListEndpointSetVersionsResponse",
+]

--- a/foundry_sdk/v3/orchestrator/__init__.py
+++ b/foundry_sdk/v3/orchestrator/__init__.py
@@ -13,8 +13,12 @@
 #  limitations under the License.
 
 
-# The version is set during the publishing step (since we can't know the version in advance)
-# using the autorelease bot
-__version__ = "0.0.0"
+from foundry_sdk.v3.orchestrator._client import (
+    AsyncOrchestratorClient,
+    OrchestratorClient,
+)
 
-__openapi_document_version__ = "1.1786.0"
+__all__ = [
+    "OrchestratorClient",
+    "AsyncOrchestratorClient",
+]

--- a/foundry_sdk/v3/orchestrator/_client.py
+++ b/foundry_sdk/v3/orchestrator/_client.py
@@ -1,0 +1,78 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import typing
+from functools import cached_property
+
+from foundry_sdk import _core as core
+
+
+class OrchestratorClient:
+    """
+    The API client for the Orchestrator Namespace.
+
+    :param auth: Your auth configuration.
+    :param hostname: The hostname supplier for resolving base URLs.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: core.Auth,
+        hostname: typing.Union[str, core.HostnameSupplier],
+        config: typing.Optional[core.Config] = None,
+    ):
+        self._auth = auth
+        if isinstance(hostname, core.HostnameSupplier):
+            self._hostname_supplier = hostname
+        else:
+            self._hostname_supplier = core.create_hostname_supplier(hostname, config)
+        self._hostname = self._hostname_supplier.get_hostname()
+
+        self._config = config
+
+    @cached_property
+    def ProcessExecution(self):
+        from foundry_sdk.v3.orchestrator.process_execution import ProcessExecutionClient
+
+        return ProcessExecutionClient(
+            auth=self._auth,
+            hostname=self._hostname_supplier,
+            config=self._config,
+        )
+
+
+class AsyncOrchestratorClient:
+    """
+    The Async API client for the Orchestrator Namespace.
+
+    :param auth: Your auth configuration.
+    :param hostname: The hostname supplier for resolving base URLs.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: core.Auth,
+        hostname: typing.Union[str, core.HostnameSupplier],
+        config: typing.Optional[core.Config] = None,
+    ):
+        from foundry_sdk.v3.orchestrator.process_execution import (
+            AsyncProcessExecutionClient,
+        )
+
+        self.ProcessExecution = AsyncProcessExecutionClient(
+            auth=auth, hostname=hostname, config=config
+        )

--- a/foundry_sdk/v3/orchestrator/errors.py
+++ b/foundry_sdk/v3/orchestrator/errors.py
@@ -1,0 +1,99 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import typing
+from dataclasses import dataclass
+
+import typing_extensions
+
+from foundry_sdk import _core as core
+from foundry_sdk import _errors as errors
+from foundry_sdk.v3.orchestrator import models as orchestrator_models
+
+
+class CompleteProcessExecutionSignalPermissionDeniedParameters(typing_extensions.TypedDict):
+    """
+    The token does not have permission to complete this signal. Signals can only be completed by the token
+    that originally invoked the process execution.
+    """
+
+    __pydantic_config__ = {"extra": "allow"}  # type: ignore
+
+    processExecutionId: orchestrator_models.ProcessExecutionId
+    signalId: orchestrator_models.SignalId
+
+
+@dataclass
+class CompleteProcessExecutionSignalPermissionDenied(errors.PermissionDeniedError):
+    name: typing.Literal["CompleteProcessExecutionSignalPermissionDenied"]
+    parameters: CompleteProcessExecutionSignalPermissionDeniedParameters
+    error_instance_id: str
+
+
+class ProcessExecutionExpiredParameters(typing_extensions.TypedDict):
+    """
+    The process execution can no longer accept signal completions because its data is outside the retention
+    window.
+    """
+
+    __pydantic_config__ = {"extra": "allow"}  # type: ignore
+
+    processExecutionId: orchestrator_models.ProcessExecutionId
+    expiredTime: core.AwareDatetime
+    """The time at which the process execution's data expired."""
+
+
+@dataclass
+class ProcessExecutionExpired(errors.BadRequestError):
+    name: typing.Literal["ProcessExecutionExpired"]
+    parameters: ProcessExecutionExpiredParameters
+    error_instance_id: str
+
+
+class ProcessExecutionNotFoundParameters(typing_extensions.TypedDict):
+
+    __pydantic_config__ = {"extra": "allow"}  # type: ignore
+
+    processExecutionId: orchestrator_models.ProcessExecutionId
+
+
+@dataclass
+class ProcessExecutionNotFound(errors.NotFoundError):
+    name: typing.Literal["ProcessExecutionNotFound"]
+    parameters: ProcessExecutionNotFoundParameters
+    error_instance_id: str
+
+
+class ProcessExecutionSignalNotFoundParameters(typing_extensions.TypedDict):
+
+    __pydantic_config__ = {"extra": "allow"}  # type: ignore
+
+    signalId: orchestrator_models.SignalId
+    processExecutionId: orchestrator_models.ProcessExecutionId
+
+
+@dataclass
+class ProcessExecutionSignalNotFound(errors.NotFoundError):
+    name: typing.Literal["ProcessExecutionSignalNotFound"]
+    parameters: ProcessExecutionSignalNotFoundParameters
+    error_instance_id: str
+
+
+__all__ = [
+    "CompleteProcessExecutionSignalPermissionDenied",
+    "ProcessExecutionExpired",
+    "ProcessExecutionNotFound",
+    "ProcessExecutionSignalNotFound",
+]

--- a/foundry_sdk/v3/orchestrator/models.py
+++ b/foundry_sdk/v3/orchestrator/models.py
@@ -1,0 +1,50 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+from __future__ import annotations
+
+import typing
+
+import pydantic
+import typing_extensions
+
+from foundry_sdk import _core as core
+
+
+class CompleteProcessExecutionSignalRequest(core.ModelBase):
+    """The data to attach to a signal completion."""
+
+    payload: typing.Optional[typing.Any] = None
+    """
+    Arbitrary JSON passed to the process execution that consumes the signal. Empty when the completion
+    carries no payload.
+    """
+
+
+ProcessExecutionId: typing_extensions.TypeAlias = str
+"""Identifies a single execution of a durable process run by the platform."""
+
+
+SignalId: typing_extensions.TypeAlias = str
+"""Identifies a signal on a process execution."""
+
+
+core.resolve_forward_references_in_module(__name__)
+
+__all__ = [
+    "CompleteProcessExecutionSignalRequest",
+    "ProcessExecutionId",
+    "SignalId",
+]

--- a/foundry_sdk/v3/orchestrator/process_execution.py
+++ b/foundry_sdk/v3/orchestrator/process_execution.py
@@ -1,0 +1,127 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import typing
+from functools import cached_property
+
+import pydantic
+import typing_extensions
+
+from foundry_sdk import _core as core
+from foundry_sdk import _errors as errors
+
+
+class ProcessExecutionClient:
+    """
+    The API client for the ProcessExecution Resource.
+
+    :param auth: Your auth configuration.
+    :param hostname: The hostname supplier for resolving base URLs.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: core.Auth,
+        hostname: typing.Union[str, core.HostnameSupplier],
+        config: typing.Optional[core.Config] = None,
+    ):
+        self._auth = auth
+        if isinstance(hostname, core.HostnameSupplier):
+            self._hostname_supplier = hostname
+        else:
+            self._hostname_supplier = core.create_hostname_supplier(hostname, config)
+        self._hostname = self._hostname_supplier.get_hostname()
+        self._config = config
+        self._api_client = core.ApiClient(
+            auth=auth, hostname=self._hostname_supplier, config=config
+        )
+
+        self.with_streaming_response = _ProcessExecutionClientStreaming(self)
+        self.with_raw_response = _ProcessExecutionClientRaw(self)
+
+    @cached_property
+    def Signal(self):
+        from foundry_sdk.v3.orchestrator.process_execution_signal import (
+            ProcessExecutionSignalClient,
+        )
+
+        return ProcessExecutionSignalClient(
+            auth=self._auth,
+            hostname=self._hostname_supplier,
+            config=self._config,
+        )
+
+
+class _ProcessExecutionClientRaw:
+    def __init__(self, client: ProcessExecutionClient) -> None:
+        pass
+
+
+class _ProcessExecutionClientStreaming:
+    def __init__(self, client: ProcessExecutionClient) -> None:
+        pass
+
+
+class AsyncProcessExecutionClient:
+    """
+    The API client for the ProcessExecution Resource.
+
+    :param auth: Your auth configuration.
+    :param hostname: The hostname supplier for resolving base URLs.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: core.Auth,
+        hostname: typing.Union[str, core.HostnameSupplier],
+        config: typing.Optional[core.Config] = None,
+    ):
+        self._auth = auth
+        if isinstance(hostname, core.HostnameSupplier):
+            self._hostname_supplier = hostname
+        else:
+            self._hostname_supplier = core.create_hostname_supplier(hostname, config)
+        self._hostname = self._hostname_supplier.get_hostname()
+        self._config = config
+        self._api_client = core.AsyncApiClient(
+            auth=auth, hostname=self._hostname_supplier, config=config
+        )
+
+        self.with_streaming_response = _AsyncProcessExecutionClientStreaming(self)
+        self.with_raw_response = _AsyncProcessExecutionClientRaw(self)
+
+    @cached_property
+    def Signal(self):
+        from foundry_sdk.v3.orchestrator.process_execution_signal import (
+            AsyncProcessExecutionSignalClient,
+        )
+
+        return AsyncProcessExecutionSignalClient(
+            auth=self._auth,
+            hostname=self._hostname_supplier,
+            config=self._config,
+        )
+
+
+class _AsyncProcessExecutionClientRaw:
+    def __init__(self, client: AsyncProcessExecutionClient) -> None:
+        pass
+
+
+class _AsyncProcessExecutionClientStreaming:
+    def __init__(self, client: AsyncProcessExecutionClient) -> None:
+        pass

--- a/foundry_sdk/v3/orchestrator/process_execution_signal.py
+++ b/foundry_sdk/v3/orchestrator/process_execution_signal.py
@@ -1,0 +1,230 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import typing
+
+import pydantic
+import typing_extensions
+
+from foundry_sdk import _core as core
+from foundry_sdk import _errors as errors
+from foundry_sdk.v3.orchestrator import errors as orchestrator_errors
+from foundry_sdk.v3.orchestrator import models as orchestrator_models
+
+
+class ProcessExecutionSignalClient:
+    """
+    The API client for the ProcessExecutionSignal Resource.
+
+    :param auth: Your auth configuration.
+    :param hostname: The hostname supplier for resolving base URLs.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: core.Auth,
+        hostname: typing.Union[str, core.HostnameSupplier],
+        config: typing.Optional[core.Config] = None,
+    ):
+        self._auth = auth
+        if isinstance(hostname, core.HostnameSupplier):
+            self._hostname_supplier = hostname
+        else:
+            self._hostname_supplier = core.create_hostname_supplier(hostname, config)
+        self._hostname = self._hostname_supplier.get_hostname()
+        self._config = config
+        self._api_client = core.ApiClient(
+            auth=auth, hostname=self._hostname_supplier, config=config
+        )
+
+        self.with_streaming_response = _ProcessExecutionSignalClientStreaming(self)
+        self.with_raw_response = _ProcessExecutionSignalClientRaw(self)
+
+    @core.maybe_ignore_preview
+    @pydantic.validate_call
+    @errors.handle_unexpected
+    def complete(
+        self,
+        process_execution_id: orchestrator_models.ProcessExecutionId,
+        signal_id: orchestrator_models.SignalId,
+        *,
+        payload: typing.Optional[typing.Any] = None,
+        request_timeout: typing.Optional[core.Timeout] = None,
+        _sdk_internal: core.SdkInternal = {},
+    ) -> None:
+        """
+        Complete a signal on a process execution.
+
+        A signal may be completed multiple times, each contributing toward the execution's wait conditions.
+        If the execution is suspended waiting on this signal, it resumes once its wait conditions are
+        satisfied. Resuming an execution runs user-authored logic. Only the token that originally invoked the
+        process execution can complete its signals.
+        :param process_execution_id:
+        :type process_execution_id: ProcessExecutionId
+        :param signal_id:
+        :type signal_id: SignalId
+        :param payload: Arbitrary JSON passed to the process execution that consumes the signal. Empty when the completion carries no payload.
+        :type payload: Optional[Any]
+        :param request_timeout: timeout setting for this request in seconds.
+        :type request_timeout: Optional[int]
+        :return: Returns the result object.
+        :rtype: None
+
+        :raises CompleteProcessExecutionSignalPermissionDenied: The token does not have permission to complete this signal. Signals can only be completed by the token that originally invoked the process execution.
+        :raises ProcessExecutionExpired: The process execution can no longer accept signal completions because its data is outside the retention window.
+        :raises ProcessExecutionNotFound:
+        """
+
+        return self._api_client.call_api(
+            core.RequestInfo(
+                method="POST",
+                resource_path="/v3/platform/processExecutions/{processExecutionId}/signals/{signalId}/complete",
+                query_params={},
+                path_params={
+                    "processExecutionId": process_execution_id,
+                    "signalId": signal_id,
+                },
+                header_params={
+                    "Content-Type": "application/json",
+                },
+                body=orchestrator_models.CompleteProcessExecutionSignalRequest(
+                    payload=payload,
+                ),
+                response_type=None,
+                request_timeout=request_timeout,
+                throwable_errors={
+                    "CompleteProcessExecutionSignalPermissionDenied": orchestrator_errors.CompleteProcessExecutionSignalPermissionDenied,
+                    "ProcessExecutionExpired": orchestrator_errors.ProcessExecutionExpired,
+                    "ProcessExecutionNotFound": orchestrator_errors.ProcessExecutionNotFound,
+                },
+                response_mode=_sdk_internal.get("response_mode"),
+            ),
+        )
+
+
+class _ProcessExecutionSignalClientRaw:
+    def __init__(self, client: ProcessExecutionSignalClient) -> None:
+        def complete(_: None): ...
+
+        self.complete = core.with_raw_response(complete, client.complete)
+
+
+class _ProcessExecutionSignalClientStreaming:
+    def __init__(self, client: ProcessExecutionSignalClient) -> None:
+        pass
+
+
+class AsyncProcessExecutionSignalClient:
+    """
+    The API client for the ProcessExecutionSignal Resource.
+
+    :param auth: Your auth configuration.
+    :param hostname: The hostname supplier for resolving base URLs.
+    :param config: Optionally specify the configuration for the HTTP session.
+    """
+
+    def __init__(
+        self,
+        auth: core.Auth,
+        hostname: typing.Union[str, core.HostnameSupplier],
+        config: typing.Optional[core.Config] = None,
+    ):
+        self._auth = auth
+        if isinstance(hostname, core.HostnameSupplier):
+            self._hostname_supplier = hostname
+        else:
+            self._hostname_supplier = core.create_hostname_supplier(hostname, config)
+        self._hostname = self._hostname_supplier.get_hostname()
+        self._config = config
+        self._api_client = core.AsyncApiClient(
+            auth=auth, hostname=self._hostname_supplier, config=config
+        )
+
+        self.with_streaming_response = _AsyncProcessExecutionSignalClientStreaming(self)
+        self.with_raw_response = _AsyncProcessExecutionSignalClientRaw(self)
+
+    @core.maybe_ignore_preview
+    @pydantic.validate_call
+    @errors.handle_unexpected
+    def complete(
+        self,
+        process_execution_id: orchestrator_models.ProcessExecutionId,
+        signal_id: orchestrator_models.SignalId,
+        *,
+        payload: typing.Optional[typing.Any] = None,
+        request_timeout: typing.Optional[core.Timeout] = None,
+        _sdk_internal: core.SdkInternal = {},
+    ) -> typing.Awaitable[None]:
+        """
+        Complete a signal on a process execution.
+
+        A signal may be completed multiple times, each contributing toward the execution's wait conditions.
+        If the execution is suspended waiting on this signal, it resumes once its wait conditions are
+        satisfied. Resuming an execution runs user-authored logic. Only the token that originally invoked the
+        process execution can complete its signals.
+        :param process_execution_id:
+        :type process_execution_id: ProcessExecutionId
+        :param signal_id:
+        :type signal_id: SignalId
+        :param payload: Arbitrary JSON passed to the process execution that consumes the signal. Empty when the completion carries no payload.
+        :type payload: Optional[Any]
+        :param request_timeout: timeout setting for this request in seconds.
+        :type request_timeout: Optional[int]
+        :return: Returns the result object.
+        :rtype: typing.Awaitable[None]
+
+        :raises CompleteProcessExecutionSignalPermissionDenied: The token does not have permission to complete this signal. Signals can only be completed by the token that originally invoked the process execution.
+        :raises ProcessExecutionExpired: The process execution can no longer accept signal completions because its data is outside the retention window.
+        :raises ProcessExecutionNotFound:
+        """
+
+        return self._api_client.call_api(
+            core.RequestInfo(
+                method="POST",
+                resource_path="/v3/platform/processExecutions/{processExecutionId}/signals/{signalId}/complete",
+                query_params={},
+                path_params={
+                    "processExecutionId": process_execution_id,
+                    "signalId": signal_id,
+                },
+                header_params={
+                    "Content-Type": "application/json",
+                },
+                body=orchestrator_models.CompleteProcessExecutionSignalRequest(
+                    payload=payload,
+                ),
+                response_type=None,
+                request_timeout=request_timeout,
+                throwable_errors={
+                    "CompleteProcessExecutionSignalPermissionDenied": orchestrator_errors.CompleteProcessExecutionSignalPermissionDenied,
+                    "ProcessExecutionExpired": orchestrator_errors.ProcessExecutionExpired,
+                    "ProcessExecutionNotFound": orchestrator_errors.ProcessExecutionNotFound,
+                },
+                response_mode=_sdk_internal.get("response_mode"),
+            ),
+        )
+
+
+class _AsyncProcessExecutionSignalClientRaw:
+    def __init__(self, client: AsyncProcessExecutionSignalClient) -> None:
+        def complete(_: None): ...
+
+        self.complete = core.async_with_raw_response(complete, client.complete)
+
+
+class _AsyncProcessExecutionSignalClientStreaming:
+    def __init__(self, client: AsyncProcessExecutionSignalClient) -> None:
+        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,4 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.scripts]
 foundry_sdk_v1 = "foundry_sdk.v1.cli:cli"
 foundry_sdk_v2 = "foundry_sdk.v2.cli:cli"
+foundry_sdk_v3 = "foundry_sdk.v3.cli:cli"

--- a/scripts/generate_sdk.sh
+++ b/scripts/generate_sdk.sh
@@ -42,4 +42,5 @@ python -m platform_sdk_generator \
     --manifest_path "tmp/manifest.yml" \
     --version v1 --ir_path "tmp/combined-ir.json" \
     --version v2 --ir_path "tmp/combined-ir.json" \
+    --version v3 --ir_path "tmp/federated-ir.json" \
     --npm-snippets

--- a/scripts/generate_spec.sh
+++ b/scripts/generate_spec.sh
@@ -2,7 +2,10 @@ set -eu
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 TMP_DIR=$SCRIPT_DIR/../tmp
-MAVEN_REPO_PATH="$MAVEN_DIST_RELEASE/$(echo "$MAVEN_CONJURE_GROUP_ID" | sed 's/\./\//g')/${MAVEN_CONJURE_ARTIFACT_ID}"
+MAVEN_GROUP_PATH=$(echo "$MAVEN_CONJURE_GROUP_ID" | sed 's/\./\//g')
+MAVEN_REPO_PATH="$MAVEN_DIST_RELEASE/${MAVEN_GROUP_PATH}/${MAVEN_CONJURE_ARTIFACT_ID}"
+FEDERATED_IR_ARTIFACT_ID=api-gateway-federated-ir
+FEDERATED_IR_REPO_PATH="$MAVEN_DIST_RELEASE/${MAVEN_GROUP_PATH}/${FEDERATED_IR_ARTIFACT_ID}"
 
 mkdir -p $TMP_DIR
 
@@ -13,7 +16,8 @@ fi
 
 echo Downloading $API_GATEWAY_VERSION...
 mkdir -p "${TMP_DIR}"
-wget -P "${TMP_DIR}"  "${MAVEN_REPO_PATH}/${API_GATEWAY_VERSION}/${MAVEN_CONJURE_ARTIFACT_ID}-${API_GATEWAY_VERSION}.sls.tgz" &> /dev/null
+wget -O "${TMP_DIR}/${MAVEN_CONJURE_ARTIFACT_ID}-${API_GATEWAY_VERSION}.sls.tgz" "${MAVEN_REPO_PATH}/${API_GATEWAY_VERSION}/${MAVEN_CONJURE_ARTIFACT_ID}-${API_GATEWAY_VERSION}.sls.tgz" &> /dev/null
+wget -O "${TMP_DIR}/federated-ir.json" "${FEDERATED_IR_REPO_PATH}/${API_GATEWAY_VERSION}/${FEDERATED_IR_ARTIFACT_ID}-${API_GATEWAY_VERSION}.omni.json" &> /dev/null
 
 tar -xf "${TMP_DIR}/${MAVEN_CONJURE_ARTIFACT_ID}-${API_GATEWAY_VERSION}.sls.tgz" -C "${TMP_DIR}" --strip-components=4 "${MAVEN_CONJURE_ARTIFACT_ID}-${API_GATEWAY_VERSION}/asset/palantir/ir-v2/combined-ir.json"
 tar -xf "${TMP_DIR}/${MAVEN_CONJURE_ARTIFACT_ID}-${API_GATEWAY_VERSION}.sls.tgz" -C "${TMP_DIR}" --strip-components=2 "${MAVEN_CONJURE_ARTIFACT_ID}-${API_GATEWAY_VERSION}/deployment/manifest.yml"

--- a/tests/test_discriminators.py
+++ b/tests/test_discriminators.py
@@ -42,6 +42,9 @@ from foundry_sdk.v2.third_party_applications import (
     models as models_third_party_applications_v2,
 )  # NOQA
 from foundry_sdk.v2.widgets import models as models_widgets_v2
+from foundry_sdk.v3.core import models as models_core_v3
+from foundry_sdk.v3.endpoints import models as models_endpoints_v3
+from foundry_sdk.v3.orchestrator import models as models_orchestrator_v3
 
 
 def test_can_validate_types():
@@ -78,6 +81,9 @@ def test_can_validate_types():
             for model_name in dir(models_third_party_applications_v2)
         ],
         *[(models_widgets_v2, model_name) for model_name in dir(models_widgets_v2)],
+        *[(models_core_v3, model_name) for model_name in dir(models_core_v3)],
+        *[(models_endpoints_v3, model_name) for model_name in dir(models_endpoints_v3)],
+        *[(models_orchestrator_v3, model_name) for model_name in dir(models_orchestrator_v3)],
     ]:
         klass = getattr(models, model_name)
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -456,3 +456,63 @@ def test_widgets_v2_models_import_performance():
     )
 
     assert init_and_access_time < 1.0
+
+
+def test_import_v3_client_performance():
+    import_time = timeit.timeit(
+        stmt="import foundry_sdk.v3",
+        setup="import sys; sys.modules.pop('foundry_sdk.v3', None);",
+        number=1,
+    )
+
+    assert import_time < 0.25
+
+
+def test_client_v3_initialization_performance():
+    init_time = timeit.timeit(
+        stmt="foundry_sdk.v3.FoundryClient(foundry_sdk.UserTokenAuth(token='token'), hostname='localhost')",
+        setup="import sys; sys.modules.pop('foundry_sdk.v3', None);import foundry_sdk; import foundry_sdk.v3",
+        number=1,
+    )
+
+    assert init_time < 0.25
+
+
+def test_endpoints_v3_client_access_performance():
+    init_and_access_time = timeit.timeit(
+        stmt="foundry_sdk.v3.FoundryClient(foundry_sdk.UserTokenAuth(token='token'), hostname='localhost').endpoints",
+        setup="import sys; sys.modules.pop('foundry_sdk.v3', None);import foundry_sdk; import foundry_sdk.v3",
+        number=1,
+    )
+
+    assert init_and_access_time < 0.5
+
+
+def test_endpoints_v3_models_import_performance():
+    init_and_access_time = timeit.timeit(
+        stmt="import foundry_sdk.v3.endpoints.models",
+        setup="import sys; sys.modules.pop('foundry_sdk.v3.endpoints.models', None)",
+        number=1,
+    )
+
+    assert init_and_access_time < 0.75
+
+
+def test_orchestrator_v3_client_access_performance():
+    init_and_access_time = timeit.timeit(
+        stmt="foundry_sdk.v3.FoundryClient(foundry_sdk.UserTokenAuth(token='token'), hostname='localhost').orchestrator",
+        setup="import sys; sys.modules.pop('foundry_sdk.v3', None);import foundry_sdk; import foundry_sdk.v3",
+        number=1,
+    )
+
+    assert init_and_access_time < 0.5
+
+
+def test_orchestrator_v3_models_import_performance():
+    init_and_access_time = timeit.timeit(
+        stmt="import foundry_sdk.v3.orchestrator.models",
+        setup="import sys; sys.modules.pop('foundry_sdk.v3.orchestrator.models', None)",
+        number=1,
+    )
+
+    assert init_and_access_time < 0.75

--- a/tests/test_resource_import.py
+++ b/tests/test_resource_import.py
@@ -739,3 +739,35 @@ def test_widgets_v2_widget_set_import():
     from foundry_sdk.v2.widgets.widget_set import WidgetSetClient
 
     assert WidgetSetClient is not None
+
+
+def test_endpoints_v3_endpoint_set_import():
+    from foundry_sdk.v3.endpoints.endpoint_set import EndpointSetClient
+
+    assert EndpointSetClient is not None
+
+
+def test_endpoints_v3_endpoint_set_endpoint_import():
+    from foundry_sdk.v3.endpoints.endpoint_set_endpoint import EndpointSetEndpointClient
+
+    assert EndpointSetEndpointClient is not None
+
+
+def test_endpoints_v3_endpoint_set_version_import():
+    from foundry_sdk.v3.endpoints.endpoint_set_version import EndpointSetVersionClient
+
+    assert EndpointSetVersionClient is not None
+
+
+def test_orchestrator_v3_process_execution_import():
+    from foundry_sdk.v3.orchestrator.process_execution import ProcessExecutionClient
+
+    assert ProcessExecutionClient is not None
+
+
+def test_orchestrator_v3_process_execution_signal_import():
+    from foundry_sdk.v3.orchestrator.process_execution_signal import (
+        ProcessExecutionSignalClient,
+    )
+
+    assert ProcessExecutionSignalClient is not None


### PR DESCRIPTION
## Summary
- download the matching API Gateway federated IR and use it for v3 generation
- configure and generate the v3 Core, Endpoints, and Orchestrator namespaces while keeping v2 promoted
- regenerate SDK code, documentation, snippets, and generated tests with API Gateway 1.1786.0

## Testing
- `python -m pytest --tb=short tests` (200 passed)
- `pyright foundry_sdk`
- `black --check foundry_sdk tests`
- `bash -n scripts/generate_spec.sh scripts/generate_sdk.sh`
- `git diff --check`